### PR TITLE
Add kickstart warnings.

### DIFF
--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -42,7 +42,7 @@ from pykickstart.i18n import _
 
 import six
 import warnings
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning, KickstartDeprecationWarning
 from pykickstart.ko import KickstartObject
 from pykickstart.version import versionToString
 from pykickstart.parser import Packages
@@ -97,7 +97,7 @@ class KickstartCommand(KickstartObject):
         # If a subclass provides a removedKeywords list, warn if the user
         # continues to use some of the removed keywords
         for arg in (kw for kw in self.removedKeywords if kw in kwargs):
-            warnings.warn("The '%s' keyword has been removed." % arg, SyntaxWarning, stacklevel=2)
+            warnings.warn("The '%s' keyword has been removed." % arg, KickstartParseWarning, stacklevel=2)
 
     def __call__(self, *args, **kwargs):
         """Set multiple attributes on a subclass of KickstartCommand at once
@@ -203,7 +203,7 @@ class DeprecatedCommand(KickstartCommand):
     def parse(self, args):
         """Print a warning message if the command is seen in the input file."""
         mapping = {"lineno": self.lineno, "cmd": self.currentCmd}
-        warnings.warn(_("Ignoring deprecated command on line %(lineno)s:  The %(cmd)s command has been deprecated and no longer has any effect.  It may be removed from future releases, which will result in a fatal error from kickstart.  Please modify your kickstart file to remove this command.") % mapping, DeprecationWarning)
+        warnings.warn(_("Ignoring deprecated command on line %(lineno)s:  The %(cmd)s command has been deprecated and no longer has any effect.  It may be removed from future releases, which will result in a fatal error from kickstart.  Please modify your kickstart file to remove this command.") % mapping, KickstartDeprecationWarning)
 
 ###
 ### HANDLERS
@@ -546,7 +546,7 @@ class BaseData(KickstartObject):
         # If a subclass provides a removedKeywords list, warn if the user
         # continues to use some of the removed keywords
         for arg in (kw for kw in self.removedKeywords if kw in kwargs):
-            warnings.warn("The '%s' keyword has been removed." % arg, SyntaxWarning, stacklevel=2)
+            warnings.warn("The '%s' keyword has been removed." % arg, KickstartParseWarning, stacklevel=2)
 
     def __str__(self):
         """Return a string formatted for output to a kickstart file."""

--- a/pykickstart/commands/authconfig.py
+++ b/pykickstart/commands/authconfig.py
@@ -20,6 +20,7 @@
 import warnings
 from textwrap import dedent
 
+from pykickstart.errors import KickstartDeprecationWarning
 from pykickstart.version import FC3, versionToLongString, F28
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
@@ -67,7 +68,7 @@ class F28_Authconfig(FC3_Authconfig):
 
     def parse(self, args):
         warnings.warn("The authconfig command will be deprecated, use authselect "
-                      "instead.", DeprecationWarning)
+                      "instead.", KickstartDeprecationWarning)
 
         return super(F28_Authconfig, self).parse(args)
 

--- a/pykickstart/commands/btrfs.py
+++ b/pykickstart/commands/btrfs.py
@@ -20,7 +20,7 @@
 #
 from pykickstart.version import F17, F23, RHEL8, versionToLongString
 from pykickstart.base import BaseData, KickstartCommand, DeprecatedCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -230,7 +230,7 @@ class F17_BTRFS(KickstartCommand):
 
         # Check for duplicates in the data list.
         if data in self.dataList():
-            warnings.warn(_("A btrfs volume with the mountpoint %s has already been defined.") % data.label)
+            warnings.warn(_("A btrfs volume with the mountpoint %s has already been defined.") % data.label, KickstartParseWarning)
 
         return data
 

--- a/pykickstart/commands/device.py
+++ b/pykickstart/commands/device.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import versionToLongString, FC3, F24
 from pykickstart.base import BaseData, DeprecatedCommand, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -153,7 +153,7 @@ class F8_Device(FC3_Device):
 
         # Check for duplicates in the data list.
         if dd in self.dataList():
-            warnings.warn(_("A module with the name %s has already been defined.") % dd.moduleName)
+            warnings.warn(_("A module with the name %s has already been defined.") % dd.moduleName, KickstartParseWarning)
 
         return dd
 

--- a/pykickstart/commands/dmraid.py
+++ b/pykickstart/commands/dmraid.py
@@ -18,6 +18,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
+from pykickstart.errors import KickstartParseWarning
 from pykickstart.version import versionToLongString, FC6, F24
 from pykickstart.base import BaseData, DeprecatedCommand, KickstartCommand
 from pykickstart.options import KSOptionParser
@@ -87,7 +88,7 @@ class FC6_DmRaid(KickstartCommand):
 
         # Check for duplicates in the data list.
         if dm in self.dataList():
-            warnings.warn(_("A DM RAID device with the name %(name)s and devices %(devices)s has already been defined.") % {"name": dm.name, "devices": dm.devices})
+            warnings.warn(_("A DM RAID device with the name %(name)s and devices %(devices)s has already been defined.") % {"name": dm.name, "devices": dm.devices}, KickstartParseWarning)
 
         return dm
 

--- a/pykickstart/commands/fcoe.py
+++ b/pykickstart/commands/fcoe.py
@@ -18,6 +18,7 @@
 # with the express permission of Red Hat, Inc.
 #
 from pykickstart.version import F12, F13, F28, RHEL7
+from pykickstart.errors import KickstartParseWarning
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser
 
@@ -139,7 +140,7 @@ class F12_Fcoe(KickstartCommand):
 
         # Check for duplicates in the data list.
         if zd in self.dataList():
-            warnings.warn(_("A FCOE device with the name %s has already been defined.") % zd.nic)
+            warnings.warn(_("A FCOE device with the name %s has already been defined.") % zd.nic, KickstartParseWarning)
 
         return zd
 

--- a/pykickstart/commands/group.py
+++ b/pykickstart/commands/group.py
@@ -17,6 +17,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
+from pykickstart.errors import KickstartParseWarning
 from pykickstart.version import F12
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser
@@ -91,7 +92,7 @@ class F12_Group(KickstartCommand):
 
         # Check for duplicates in the data list.
         if gd in self.dataList():
-            warnings.warn(_("A group with the name %s has already been defined.") % gd.name)
+            warnings.warn(_("A group with the name %s has already been defined.") % gd.name, KickstartParseWarning)
 
         return gd
 

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -20,7 +20,7 @@
 from pykickstart.version import FC3, FC4, F9, F12, F14, F15, F17, F18, F20, F21
 from pykickstart.version import F23, RHEL5, RHEL6, RHEL7, RHEL8, versionToLongString
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser, commaSplit
 
 import warnings
@@ -440,7 +440,7 @@ class FC3_LogVol(KickstartCommand):
 
         # Check for duplicates in the data list.
         if lvd in self.dataList():
-            warnings.warn(_("A logical volume with the name %(logical_volume_name)s has already been defined in volume group %(volume_group)s.") % {"logical_volume_name": lvd.name, "volume_group": lvd.vgname})
+            warnings.warn(_("A logical volume with the name %(logical_volume_name)s has already been defined in volume group %(volume_group)s.") % {"logical_volume_name": lvd.name, "volume_group": lvd.vgname}, KickstartParseWarning)
 
         return lvd
 

--- a/pykickstart/commands/network.py
+++ b/pykickstart/commands/network.py
@@ -23,7 +23,7 @@ from pykickstart.version import versionToLongString, RHEL4, RHEL5, RHEL6, RHEL7
 from pykickstart.version import FC3, FC4, FC6, F8, F9, F16, F19, F20, F21, F22, F25, F27
 from pykickstart.constants import BOOTPROTO_BOOTP, BOOTPROTO_DHCP, BOOTPROTO_IBFT, BOOTPROTO_QUERY, BOOTPROTO_STATIC, BIND_TO_MAC
 from pykickstart.options import KSOptionParser, ksboolean
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 
 import warnings
 from pykickstart.i18n import _
@@ -475,7 +475,7 @@ class FC3_Network(KickstartCommand):
 
         # Check for duplicates in the data list.
         if nd in self.dataList():
-            warnings.warn(_("A network device with the name %s has already been defined.") % nd.device)
+            warnings.warn(_("A network device with the name %s has already been defined.") % nd.device, KickstartParseWarning)
 
         return nd
 

--- a/pykickstart/commands/nvdimm.py
+++ b/pykickstart/commands/nvdimm.py
@@ -20,7 +20,7 @@
 
 import warnings
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser, commaSplit
 from pykickstart.constants import NVDIMM_MODE_SECTOR, NVDIMM_ACTION_RECONFIGURE, \
     NVDIMM_ACTION_USE
@@ -145,10 +145,10 @@ class F28_Nvdimm(KickstartCommand):
         if nvdimm_data in self.dataList():
             if nvdimm_data.namespace:
                 warnings.warn(_("An action %(action)s on namespace %(namespace)s has already been defined.")
-                              % {"action": action, "namespace": nvdimm_data.namespace})
+                              % {"action": action, "namespace": nvdimm_data.namespace}, KickstartParseWarning)
             if nvdimm_data.blockdevs:
                 warnings.warn(_("An action %(action)s on devices %(blockdevs)s has already been defined.")
-                              % {"action": action, "blockdevs": nvdimm_data.blockdevs})
+                              % {"action": action, "blockdevs": nvdimm_data.blockdevs}, KickstartParseWarning)
 
         if action == NVDIMM_ACTION_RECONFIGURE:
             if not nvdimm_data.namespace:

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -20,7 +20,7 @@
 from pykickstart.version import RHEL5, RHEL6, RHEL8, versionToLongString
 from pykickstart.version import FC3, FC4, F9, F11, F12, F14, F17, F18, F23
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -413,7 +413,7 @@ class FC3_Partition(KickstartCommand):
 
         # Check for duplicates in the data list.
         if pd.mountpoint != "swap" and pd in self.dataList():
-            warnings.warn(_("A partition with the mountpoint %s has already been defined.") % pd.mountpoint)
+            warnings.warn(_("A partition with the mountpoint %s has already been defined.") % pd.mountpoint, KickstartParseWarning)
 
         return pd
 

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -21,7 +21,7 @@ from textwrap import dedent
 from pykickstart.version import versionToLongString, RHEL5, RHEL6, FC3, FC4, FC5
 from pykickstart.version import F7, F9, F12, F13, F14, F15, F18, F23, F25, RHEL8
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -423,7 +423,7 @@ class FC3_Raid(KickstartCommand):
 
         # Check for duplicates in the data list.
         if rd in self.dataList():
-            warnings.warn(_("A RAID device with the name %s has already been defined.") % rd.device)
+            warnings.warn(_("A RAID device with the name %s has already been defined.") % rd.device, KickstartParseWarning)
 
         if not rd.preexist and not rd.level:
             raise KickstartParseError("RAID Partition defined without RAID level", lineno=self.lineno)

--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -21,7 +21,7 @@ from textwrap import dedent
 from pykickstart.version import versionToLongString
 from pykickstart.version import FC6, F8, F11, F13, F14, F15, F21, F27
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartError, KickstartParseError
+from pykickstart.errors import KickstartError, KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser, commaSplit, ksboolean
 
 import warnings
@@ -264,7 +264,7 @@ class FC6_Repo(KickstartCommand):
 
         # Check for duplicates in the data list.
         if rd in self.dataList():
-            warnings.warn(_("A repo with the name %s has already been defined.") % rd.name)
+            warnings.warn(_("A repo with the name %s has already been defined.") % rd.name, KickstartParseWarning)
 
         return rd
 

--- a/pykickstart/commands/sshkey.py
+++ b/pykickstart/commands/sshkey.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import F22
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser
 import warnings
 
@@ -106,7 +106,7 @@ class F22_SshKey(KickstartCommand):
         ud.lineno = self.lineno
 
         if ud in self.dataList():
-            warnings.warn(_("An ssh user with the name %s has already been defined.") % ud.username)
+            warnings.warn(_("An ssh user with the name %s has already been defined.") % ud.username, KickstartParseWarning)
 
         return ud
 

--- a/pykickstart/commands/sshpw.py
+++ b/pykickstart/commands/sshpw.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import F13, F24
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser
 import warnings
 
@@ -167,7 +167,7 @@ class F13_SshPw(KickstartCommand):
         ud.lineno = self.lineno
 
         if ud in self.dataList():
-            warnings.warn(_("An ssh user with the name %s has already been defined.") % ud.username)
+            warnings.warn(_("An ssh user with the name %s has already been defined.") % ud.username, KickstartParseWarning)
 
         return ud
 

--- a/pykickstart/commands/user.py
+++ b/pykickstart/commands/user.py
@@ -17,6 +17,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
+from pykickstart.errors import KickstartParseWarning
 from pykickstart.version import FC6, F8, F12, F19, F24
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser, commaSplit
@@ -198,7 +199,7 @@ class FC6_User(KickstartCommand):
 
         # Check for duplicates in the data list.
         if ud in self.dataList():
-            warnings.warn(_("A user with the name %s has already been defined.") % ud.name)
+            warnings.warn(_("A user with the name %s has already been defined.") % ud.name, KickstartParseWarning)
 
         return ud
 

--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, F16, F21
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -177,7 +177,7 @@ class FC3_VolGroup(KickstartCommand):
 
         # Check for duplicates in the data list.
         if vg in self.dataList():
-            warnings.warn(_("A volgroup with the name %s has already been defined.") % vg.vgname)
+            warnings.warn(_("A volgroup with the name %s has already been defined.") % vg.vgname, KickstartParseWarning)
 
         return vg
 

--- a/pykickstart/commands/zerombr.py
+++ b/pykickstart/commands/zerombr.py
@@ -18,6 +18,8 @@
 # with the express permission of Red Hat, Inc.
 #
 import warnings
+
+from pykickstart.errors import KickstartDeprecationWarning
 from pykickstart.version import FC3
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
@@ -57,7 +59,7 @@ class FC3_ZeroMbr(KickstartCommand):
         extra = self.op.parse_known_args(args=args, lineno=self.lineno)[1]
 
         if extra:
-            warnings.warn(_("Ignoring deprecated option on line %s:  The zerombr command no longer takes any options.  In future releases, this will result in a fatal error from kickstart.  Please modify your kickstart file to remove any options.") % self.lineno, DeprecationWarning)
+            warnings.warn(_("Ignoring deprecated option on line %s:  The zerombr command no longer takes any options.  In future releases, this will result in a fatal error from kickstart.  Please modify your kickstart file to remove any options.") % self.lineno, KickstartDeprecationWarning)
 
         self.zerombr = True
         return self

--- a/pykickstart/commands/zfcp.py
+++ b/pykickstart/commands/zfcp.py
@@ -17,6 +17,7 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc.
 #
+from pykickstart.errors import KickstartParseWarning
 from pykickstart.version import FC3, F12, F14
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.options import KSOptionParser
@@ -116,7 +117,7 @@ class FC3_ZFCP(KickstartCommand):
 
         # Check for duplicates in the data list.
         if zd in self.dataList():
-            warnings.warn(_("A zfcp with this information has already been defined."))
+            warnings.warn(_("A zfcp with this information has already been defined."), KickstartParseWarning)
 
         return zd
 

--- a/pykickstart/errors.py
+++ b/pykickstart/errors.py
@@ -18,7 +18,7 @@
 # with the express permission of Red Hat, Inc.
 #
 """
-Error handling classes and functions.
+Error and warning handling classes and functions.
 
 This module exports several exception classes:
 
@@ -31,6 +31,16 @@ This module exports several exception classes:
 
     KickstartVersionError - An exception for errors relating to unsupported
                             syntax versions.
+
+And some warning classes:
+
+    KickstartWarning - A generic warning class.
+
+    KickstartParseWarning - A class for warnings occurring during parsing.
+
+    KickstartDeprecationWarning - A class for warnings occurring during parsing
+                                  related to deprecated commands and options.
+
 """
 import warnings
 from pykickstart.i18n import _
@@ -103,5 +113,21 @@ class KickstartValueError(KickstartError):
 class KickstartVersionError(KickstartError):
     """An exception class for errors related to using an incorrect version of
        kickstart syntax.
+    """
+    pass
+
+class KickstartWarning(Warning):
+    """A generic warning class for unspecific conditions."""
+    pass
+
+class KickstartParseWarning(KickstartWarning, UserWarning):
+    """A class for warnings occurring during parsing an input file, such as
+       defining duplicate entries and setting removed keywords.
+    """
+    pass
+
+class KickstartDeprecationWarning(KickstartParseWarning, DeprecationWarning):
+    """A class for warnings occurring during parsing related to using deprecated
+       commands and options.
     """
     pass

--- a/pykickstart/options.py
+++ b/pykickstart/options.py
@@ -48,7 +48,7 @@ import textwrap
 from argparse import RawTextHelpFormatter, SUPPRESS
 from argparse import Action, ArgumentParser, ArgumentTypeError
 
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.version import versionToString, versionToLongString
 
 from pykickstart.i18n import _
@@ -187,7 +187,7 @@ class KSOptionParser(ArgumentParser):
                 self.error(_("The %(option)s option was removed in version %(removed)s, but you are using kickstart syntax version %(version)s.") % mapping)
         elif action.deprecated is True or (self.version and type(action.deprecated) == int and self.version >= action.deprecated):
             mapping = {"lineno": self.lineno, "option": action.option_strings[0]}
-            warnings.warn(_("Ignoring deprecated option on line %(lineno)s:  The %(option)s option has been deprecated and no longer has any effect.  It may be removed from future releases, which will result in a fatal error from kickstart.  Please modify your kickstart file to remove this option.") % mapping, DeprecationWarning)
+            warnings.warn(_("Ignoring deprecated option on line %(lineno)s:  The %(option)s option has been deprecated and no longer has any effect.  It may be removed from future releases, which will result in a fatal error from kickstart.  Please modify your kickstart file to remove this option.") % mapping, KickstartDeprecationWarning)
 
         return option_tuple
 

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -42,7 +42,7 @@ import warnings
 from ordered_set import OrderedSet
 
 from pykickstart import constants, version
-from pykickstart.errors import KickstartError, KickstartParseError
+from pykickstart.errors import KickstartError, KickstartParseError, KickstartParseWarning
 from pykickstart.ko import KickstartObject
 from pykickstart.load import load_to_str
 from pykickstart.options import KSOptionParser
@@ -755,7 +755,7 @@ class KickstartParser(object):
                             # NullSection for the header we just saw.  Then nothing else
                             # needs to change.  You can turn this warning into an error via
                             # ksvalidator, or the warnings module.
-                            warnings.warn(_("Potentially unknown section seen at line %(lineno)s: %(sectionName)s") % {"lineno": lineno, "sectionName": newSection})
+                            warnings.warn(_("Potentially unknown section seen at line %(lineno)s: %(sectionName)s") % {"lineno": lineno, "sectionName": newSection}, KickstartParseWarning)
                             self.registerSection(NullSection(self.handler, sectionOpen=newSection))
 
                     self._state = newSection

--- a/tests/baseclass.py
+++ b/tests/baseclass.py
@@ -9,7 +9,8 @@ import six
 
 import importlib
 
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning, \
+    KickstartParseWarning
 from pykickstart.parser import KickstartParser
 from pykickstart.version import DEVEL, makeVersion, returnClassForVersion
 from pykickstart.i18n import _
@@ -83,8 +84,8 @@ class CommandSequenceTest(ParserTest):
         '''Perform any command setup'''
         ParserTest.setUp(self)
 
-        # turn warnings into errors so we can catch them
-        warnings.simplefilter("error", category=UserWarning)
+        # turn all parse warnings into errors so we can catch them
+        warnings.simplefilter("error", category=KickstartParseWarning)
 
     def tearDown(self):
         '''Undo anything performed by setUp(self)'''
@@ -108,11 +109,11 @@ class CommandTest(unittest.TestCase):
         '''Perform any command setup'''
         unittest.TestCase.setUp(self)
 
-        # turn warnings into errors so we can catch them
-        warnings.simplefilter("error", category=UserWarning)
+        # turn all parse warnings into errors so we can catch them
+        warnings.simplefilter("error", category=KickstartParseWarning)
 
-        # ignore DeprecationWarning
-        warnings.simplefilter("ignore", category=DeprecationWarning, append=0)
+        # ignore deprecation warnings
+        warnings.simplefilter("ignore", category=KickstartDeprecationWarning)
 
     def tearDown(self):
         '''Undo anything performed by setUp(self)'''

--- a/tests/command_usage.py
+++ b/tests/command_usage.py
@@ -1,3 +1,4 @@
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandSequenceTest
 
 
@@ -79,4 +80,4 @@ part swap --size=2048 --fstype=swap""")
         # Two root partitions is not.
         self.assert_parse_error("""
 part / --size=1024 --fstype=ext4
-part / --size=2048 --fstype=ext4""", exception=UserWarning)
+part / --size=2048 --fstype=ext4""", exception=KickstartParseWarning)

--- a/tests/commands/authconfig.py
+++ b/tests/commands/authconfig.py
@@ -1,4 +1,6 @@
 import unittest
+
+from pykickstart.errors import KickstartDeprecationWarning
 from tests.baseclass import CommandTest
 
 
@@ -20,10 +22,10 @@ class F28_TestCase(FC3_TestCase):
     def runTest(self):
         super().runTest()
 
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(KickstartDeprecationWarning):
             self.assert_parse("authconfig")
 
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(KickstartDeprecationWarning):
             self.assert_parse("auth")
 
 

--- a/tests/commands/btrfs.py
+++ b/tests/commands/btrfs.py
@@ -21,7 +21,8 @@
 import unittest
 from tests.baseclass import CommandTest
 from pykickstart.commands.btrfs import F17_BTRFSData
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
+
 
 class BTRFS_TestCase(unittest.TestCase):
     def runTest(self):
@@ -122,7 +123,7 @@ class F17_TestCase(CommandTest):
         self.assertEqual(btrfs.__str__(), "btrfs btrfs --subvol --name=home /home\n")
 
         # check for duplicates in the btrfslist when parsing
-        with self.assertRaises(UserWarning):
+        with self.assertRaises(KickstartParseWarning):
             btrfs.parse("btrfs /home --subvol --name=home".split(" "))
 
         # equality

--- a/tests/commands/device.py
+++ b/tests/commands/device.py
@@ -18,6 +18,8 @@
 # with the express permission of Red Hat, Inc.
 #
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest
 
 from pykickstart.base import DeprecatedCommand
@@ -93,7 +95,7 @@ class F8_TestCase(CommandTest):
 
         # test if trying to define the same module again will raise
         # a warning
-        with self.assertRaises(UserWarning):
+        with self.assertRaises(KickstartParseWarning):
             device.parse(["MODNAME"])
 
         dd = self.handler().DeviceData()

--- a/tests/commands/dmraid.py
+++ b/tests/commands/dmraid.py
@@ -18,6 +18,8 @@
 #
 
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.dmraid import FC6_DmRaidData
 from pykickstart.base import DeprecatedCommand
@@ -89,7 +91,7 @@ dmraid --name=raidB --dev=deviceB""")
 
         self.assert_parse_error("""
 dmraid --name=raidA --dev=deviceA
-dmraid --name=raidA --dev=deviceA""", UserWarning)
+dmraid --name=raidA --dev=deviceA""", KickstartParseWarning)
 
 class F24_TestCase(FC6_TestCase):
     def runTest(self):

--- a/tests/commands/fcoe.py
+++ b/tests/commands/fcoe.py
@@ -19,6 +19,8 @@
 #
 
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.fcoe import F12_FcoeData
 from pykickstart.version import F12
@@ -79,7 +81,7 @@ fcoe --nic=eth1""")
 
         self.assert_parse_error("""
 fcoe --nic=eth0
-fcoe --nic=eth0""", UserWarning)
+fcoe --nic=eth0""", KickstartParseWarning)
 
 class F13_TestCase(F12_TestCase):
     def runTest(self):

--- a/tests/commands/group.py
+++ b/tests/commands/group.py
@@ -19,6 +19,8 @@
 #
 
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.group import F12_GroupData
 from pykickstart.version import F12
@@ -86,7 +88,7 @@ group --name=othertest""")
 
         self.assert_parse_error("""
 group --name=test --gid=1000
-group --name=test --gid=1010""", UserWarning)
+group --name=test --gid=1010""", KickstartParseWarning)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/logvol.py
+++ b/tests/commands/logvol.py
@@ -1,5 +1,7 @@
 import six
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.logvol import  RHEL5_LogVolData, RHEL6_LogVolData
 from pykickstart.commands.logvol import FC3_LogVolData, F9_LogVolData, \
@@ -159,7 +161,7 @@ logvol /home --size=1024 --name=nameA --vgname=vgB""")
 
         self.assert_parse_error("""
 logvol / --size=1024 --name=nameA --vgname=vgA
-logvol /home --size=1024 --name=nameA --vgname=vgA""", UserWarning)
+logvol /home --size=1024 --name=nameA --vgname=vgA""", KickstartParseWarning)
 
 class FC4_TestCase(FC3_TestCase):
     def runTest(self):

--- a/tests/commands/network.py
+++ b/tests/commands/network.py
@@ -18,6 +18,8 @@
 # with the express permission of Red Hat, Inc.
 #
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.network import FC3_NetworkData, FC4_NetworkData, \
     FC6_NetworkData, F16_NetworkData, F25_NetworkData, \
@@ -130,7 +132,7 @@ network --device=eth1""")
 
         self.assert_parse_error("""
 network --device=eth0
-network --device=eth0""", UserWarning)
+network --device=eth0""", KickstartParseWarning)
 
 class RHEL4_TestCase(FC3_TestCase):
     def runTest(self):

--- a/tests/commands/raid.py
+++ b/tests/commands/raid.py
@@ -21,7 +21,7 @@
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.version import FC3, F20
 from pykickstart.commands.raid import FC3_RaidData
 
@@ -167,7 +167,7 @@ raid /usr --device=md1 --level=0 raid.01 raid.02
         self.assert_parse_error("""
 raid / --device=md0 --level=0 raid.01 raid.02
 raid / --device=md0 --level=0 raid.01 raid.02
-""", UserWarning)
+""", KickstartParseWarning)
 
 class FC4_TestCase(FC3_TestCase):
     def runTest(self):

--- a/tests/commands/repo.py
+++ b/tests/commands/repo.py
@@ -21,7 +21,7 @@
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 
-from pykickstart.errors import KickstartError
+from pykickstart.errors import KickstartError, KickstartParseWarning
 from pykickstart.version import FC6
 
 class FC6_TestCase(CommandTest):
@@ -78,7 +78,7 @@ repo --name=repoB --baseurl=http://www.domain.com""")
 
         self.assert_parse_error("""
 repo --name=repoA --baseurl=http://www.domain.com
-repo --name=repoA --baseurl=http://www.domain.com""", UserWarning)
+repo --name=repoA --baseurl=http://www.domain.com""", KickstartParseWarning)
 
 class F8_TestCase(FC6_TestCase):
     def runTest(self, urlRequired=True):

--- a/tests/commands/sshkey.py
+++ b/tests/commands/sshkey.py
@@ -18,6 +18,8 @@
 # with the express permission of Red Hat, Inc.
 #
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.sshkey import F22_SshKeyData
 from pykickstart.version import F22
@@ -83,7 +85,7 @@ sshkey --username=otherguy 'this is the key'""")
 
         self.assert_parse_error("""
 sshkey --username=someguy 'this is the key'
-sshkey --username=someguy 'this is the key'""", UserWarning)
+sshkey --username=someguy 'this is the key'""", KickstartParseWarning)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/sshpw.py
+++ b/tests/commands/sshpw.py
@@ -18,6 +18,8 @@
 # with the express permission of Red Hat, Inc.
 #
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.sshpw import F13_SshPwData, F13_SshPw, F24_SshPwData
 from pykickstart.version import F13
@@ -114,7 +116,7 @@ sshpw --username=otherguy --iscrypted passwordA""")
 
         self.assert_parse_error("""
 sshpw --username=someguy --iscrypted passwordA
-sshpw --username=someguy --iscrypted passwordB""", UserWarning)
+sshpw --username=someguy --iscrypted passwordB""", KickstartParseWarning)
 
 class F24_TestCase(F13_TestCase):
     def runTest(self):

--- a/tests/commands/user.py
+++ b/tests/commands/user.py
@@ -19,6 +19,8 @@
 #
 
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.user import FC6_UserData
 from pykickstart.version import FC6
@@ -99,7 +101,7 @@ user --name=userB""")
         # fail - can't have two users with the same name
         self.assert_parse_error("""
 user --name=userA
-user --name=userA""", UserWarning)
+user --name=userA""", KickstartParseWarning)
 
 class F8_TestCase(FC6_TestCase):
     def runTest(self):

--- a/tests/commands/volgroup.py
+++ b/tests/commands/volgroup.py
@@ -1,7 +1,7 @@
 import unittest
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.commands.volgroup import FC3_VolGroupData, F21_VolGroupData
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
 from pykickstart.version import FC3
 
 class VolGroup_TestCase(unittest.TestCase):
@@ -96,7 +96,7 @@ volgroup vg.02 pv.01""")
 
         self.assert_parse_error("""
 volgroup vg.01 pv.01
-volgroup vg.01 pv.02""", UserWarning)
+volgroup vg.01 pv.02""", KickstartParseWarning)
 
 class F16_TestCase(FC3_TestCase):
     def runTest(self):

--- a/tests/commands/zfcp.py
+++ b/tests/commands/zfcp.py
@@ -19,6 +19,8 @@
 #
 
 import unittest
+
+from pykickstart.errors import KickstartParseWarning
 from tests.baseclass import CommandTest, CommandSequenceTest
 from pykickstart.version import F12
 from pykickstart.commands.zfcp import FC3_ZFCP, FC3_ZFCPData, F12_ZFCPData
@@ -120,7 +122,7 @@ zfcp --devnum=10 --wwpn=20 --fcplun=30""")
 
         self.assert_parse_error("""
 zfcp --devnum=1 --wwpn=2 --fcplun=3
-zfcp --devnum=1 --wwpn=2 --fcplun=3""", UserWarning)
+zfcp --devnum=1 --wwpn=2 --fcplun=3""", KickstartParseWarning)
 
 class F14_TestCase(F12_TestCase):
     def runTest(self):

--- a/tests/newsection.py
+++ b/tests/newsection.py
@@ -4,7 +4,8 @@ import warnings
 from tests.baseclass import ParserTest
 
 from pykickstart import sections
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartParseWarning
+
 
 class RawSection(sections.Section):
     def __init__(self, handler, **kwargs):
@@ -66,7 +67,7 @@ whatever2
         # pykickstart recognizes these sections, but doesn't do anything with them.
         # Be as strict as possible by turning warnings into errors, to make sure we
         # don't even warn about them.
-        warnings.simplefilter("error", category=UserWarning)
+        warnings.simplefilter("error", category=KickstartParseWarning)
         self.parser.readKickstartFromString(self.ks)
         warnings.resetwarnings()
 

--- a/tests/packages.py
+++ b/tests/packages.py
@@ -4,7 +4,7 @@ import warnings
 from tests.baseclass import ParserTest
 
 from pykickstart.constants import KS_MISSING_IGNORE
-from pykickstart.errors import KickstartParseError
+from pykickstart.errors import KickstartParseError, KickstartDeprecationWarning
 from pykickstart.parser import Group, Packages
 from pykickstart.version import DEVEL, F7, F21, RHEL6, returnClassForVersion, RHEL7
 
@@ -319,7 +319,7 @@ bash
             warnings.simplefilter("always")
             self.parser.readKickstartFromString(self.ks)
             self.assertEqual(len(w), 1)
-            self.assertIsInstance(w[-1].message, DeprecationWarning)
+            self.assertIsInstance(w[-1].message, KickstartDeprecationWarning)
 
 class Packages_Contains_Nobase_2_TestCase(ParserTest):
     def __init__(self, *args, **kwargs):

--- a/tests/tools/ksvalidator.py
+++ b/tests/tools/ksvalidator.py
@@ -7,6 +7,7 @@ from tools import ksvalidator
 from pykickstart import parser
 from tests.tools.utils import mktempfile
 from pykickstart.version import versionMap
+from pykickstart.errors import KickstartDeprecationWarning
 
 class Remove_Non_Existing_File_TestCase(TestCase):
     def runTest(self):
@@ -229,7 +230,7 @@ class Raise_DeprecationWarning_TestCase(TestCase):
 
     @mock.patch.object(parser.KickstartParser, 'readKickstart')
     def runTest(self, _mock):
-        _mock.side_effect = DeprecationWarning('Raised by test')
+        _mock.side_effect = KickstartDeprecationWarning('Raised by test')
         retval, out = ksvalidator.main([self._ks_path, "-v", "F10"])
         self.assertNotEqual(retval, 0)
         self.assertTrue("File uses a deprecated option or command" in " ".join(out))

--- a/tools/ksvalidator.py
+++ b/tools/ksvalidator.py
@@ -28,7 +28,8 @@ import warnings
 import tempfile
 import shutil
 from pykickstart.i18n import _
-from pykickstart.errors import KickstartError, KickstartParseError, KickstartVersionError
+from pykickstart.errors import KickstartError, KickstartParseError, KickstartVersionError,\
+    KickstartParseWarning, KickstartDeprecationWarning
 from pykickstart.load import load_to_file
 from pykickstart.parser import KickstartParser, preprocessKickstart
 from pykickstart.version import DEVEL, makeVersion, versionMap
@@ -94,8 +95,8 @@ def main(argv):
     ksparser = KickstartParser(handler, followIncludes=opts.followincludes,
                                errorsAreFatal=opts.firsterror)
 
-    # turn DeprecationWarnings into errors
-    warnings.filterwarnings("error")
+    # turn kickstart parse warnings into errors
+    warnings.filterwarnings(action="error", category=KickstartParseWarning)
 
     processedFile = None
 
@@ -103,7 +104,7 @@ def main(argv):
         processedFile = preprocessKickstart(f)
         ksparser.readKickstart(processedFile)
         return (cleanup(destdir, processedFile, exitval=ksparser.errorsCount), [])
-    except DeprecationWarning as err:
+    except KickstartDeprecationWarning as err:
         return (cleanup(destdir, processedFile),
                 [_("File uses a deprecated option or command.\n%s") % err])
     except KickstartParseError as err:


### PR DESCRIPTION
Pykickstart should use its own warning categories for warnings related
to parsing a kickstart file, so it will be possible to distinguish
them from warnings related to API changes.

For example, it wasn't possible to tell if the DeprecationWarning
is related to a deprecated kickstart command or a deprecated
pykickstart method.

All warnings related to parsing should use the KickstartParseWarning
category. All warnings related to deprecated commands and options
should use the KickstartDeprecationWarning category.

Since KickstartParseWarning is a subclass of UserWarning and
KickstartDeprecationWarning is a subclass of DeprecationWarning, it
should be a safe change.