### PR TITLE
Authconfig is replaced with authselect

### DIFF
--- a/pykickstart/commands/__init__.py
+++ b/pykickstart/commands/__init__.py
@@ -19,6 +19,7 @@
 #
 from pykickstart.commands import (
      authconfig,
+     authselect,
      autopart,
      autostep,
      bootloader,

--- a/pykickstart/commands/authconfig.py
+++ b/pykickstart/commands/authconfig.py
@@ -17,9 +17,13 @@
 # subject to the GNU General Public License and may only be used or replicated
 # with the express permission of Red Hat, Inc. 
 #
-from pykickstart.version import FC3
+import warnings
+from textwrap import dedent
+
+from pykickstart.version import FC3, versionToLongString, F28
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
+
 
 class FC3_Authconfig(KickstartCommand):
     removedKeywords = KickstartCommand.removedKeywords
@@ -56,3 +60,26 @@ class FC3_Authconfig(KickstartCommand):
                         See ``man authconfig``.""", version=FC3)
         return op
 
+
+class F28_Authconfig(FC3_Authconfig):
+    removedKeywords = FC3_Authconfig.removedKeywords
+    removedAttrs = FC3_Authconfig.removedAttrs
+
+    def parse(self, args):
+        warnings.warn("The authconfig command will be deprecated, use authselect "
+                      "instead.", DeprecationWarning)
+
+        return super(F28_Authconfig, self).parse(args)
+
+    def _getParser(self):
+        op = super(F28_Authconfig, self)._getParser()
+        op.description += dedent("""
+
+            .. versionchanged:: %s
+
+            The authconfig program is deprecated. This command will use the
+            authconfig compatibility tool, but you should use the authselect
+            command instead.
+
+        """ % versionToLongString(F28))
+        return op

--- a/pykickstart/commands/authselect.py
+++ b/pykickstart/commands/authselect.py
@@ -1,0 +1,56 @@
+#
+# Vendula Poncova <vponcova@redhat.com>
+#
+# Copyright 2018 Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use, modify,
+# copy, or redistribute it subject to the terms and conditions of the GNU
+# General Public License v.2.  This program is distributed in the hope that it
+# will be useful, but WITHOUT ANY WARRANTY expressed or implied, including the
+# implied warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat
+# trademarks that are incorporated in the source code or documentation are not
+# subject to the GNU General Public License and may only be used or replicated
+# with the express permission of Red Hat, Inc.
+#
+from pykickstart.base import KickstartCommand
+from pykickstart.options import KSOptionParser
+from pykickstart.version import F28
+
+
+class F28_Authselect(KickstartCommand):
+    removedKeywords = KickstartCommand.removedKeywords
+    removedAttrs = KickstartCommand.removedAttrs
+
+    def __init__(self, writePriority=0, *args, **kwargs):
+        KickstartCommand.__init__(self, writePriority, *args, **kwargs)
+        self.authselect = kwargs.get("authselect", "")
+
+    def __str__(self):
+        retval = KickstartCommand.__str__(self)
+
+        if self.authselect:
+            retval += "# System authorization information\nauthselect %s\n" % self.authselect
+
+        return retval
+
+    def parse(self, args):
+        self.authselect = self.currentLine[len(self.currentCmd):].strip()
+        return self
+
+    def _getParser(self):
+        op = KSOptionParser(prog="authselect",  description="""
+                            This command sets up the authentication options
+                            for the system. This is just a wrapper around the
+                            authselect program, so all options recognized by
+                            that program are valid for this command. See the
+                            manual page for authselect for a complete list.""",
+                            version=F28)
+
+        op.add_argument("options", metavar="[options]", help="""
+                        See ``man authselect``.""", version=F28)
+        return op

--- a/pykickstart/handlers/f28.py
+++ b/pykickstart/handlers/f28.py
@@ -27,8 +27,9 @@ class F28Handler(BaseHandler):
     version = F28
 
     commandMap = {
-        "auth": commands.authconfig.FC3_Authconfig,
-        "authconfig": commands.authconfig.FC3_Authconfig,
+        "auth": commands.authconfig.F28_Authconfig,
+        "authconfig": commands.authconfig.F28_Authconfig,
+        "authselect": commands.authselect.F28_Authselect,
         "autopart": commands.autopart.F26_AutoPart,
         "autostep": commands.autostep.FC3_AutoStep,
         "bootloader": commands.bootloader.F21_Bootloader,

--- a/tests/commands/authconfig.py
+++ b/tests/commands/authconfig.py
@@ -1,6 +1,7 @@
 import unittest
 from tests.baseclass import CommandTest
 
+
 class FC3_TestCase(CommandTest):
     command = "authconfig"
 
@@ -12,6 +13,19 @@ class FC3_TestCase(CommandTest):
         self.assert_parse("auth")
         self.assert_parse("auth --cheese", "auth --cheese\n")
         self.assert_parse("auth --cracker=CRUNCHY", "auth --cracker=CRUNCHY\n")
+
+
+class F28_TestCase(FC3_TestCase):
+
+    def runTest(self):
+        super().runTest()
+
+        with self.assertWarns(DeprecationWarning):
+            self.assert_parse("authconfig")
+
+        with self.assertWarns(DeprecationWarning):
+            self.assert_parse("auth")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/authselect.py
+++ b/tests/commands/authselect.py
@@ -1,0 +1,20 @@
+import unittest
+from tests.baseclass import CommandTest
+
+
+class F28_TestCase(CommandTest):
+    command = "authselect"
+
+    def runTest(self):
+        # pass
+        self.assert_parse("authselect")
+
+        self.assert_parse("authselect select winbind",
+                          "authselect select winbind\n")
+
+        self.assert_parse("authselect select sssd with-mkhomedir",
+                          "authselect select sssd with-mkhomedir\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -22,16 +22,6 @@ class WritePriority_TestCase(unittest.TestCase):
                 cmd = command_class()
                 if issubclass(cmd.__class__, DeprecatedCommand):
                     self.assertEqual(None, cmd.writePriority, command_class)
-                elif _name in ['rescue', 'upgrade', 'group', 'driverdisk', 'xconfig',
-                    'keyboard', 'rootpw', 'url', 'lang', 'liveimg', 'method', 'realm',
-                    'user', 'eula', 'firewall', 'ostreesetup', 'repo', 'sshkey', 'reboot',
-                    'timezone', 'network', 'sshpw', 'updates', 'device', 'vnc', 'authconfig',
-                    'autostep', 'cdrom', 'deviceprobe', 'text', 'graphical', 'firstboot', 'harddrive',
-                    'selinux', 'skipx', 'mediacheck', 'logging', 'nfs', 'services', 'ignoredisk',
-                    'interactive', 'cmdline', 'monitor', 'install', 'shutdown', 'halt',
-                    'auth', 'poweroff', 'lilocheck', 'langsupport', 'mouse', 'key',
-                    'unsupported_hardware', 'hmc', 'mount']:
-                    self.assertEqual(0, cmd.writePriority, command_class)
                 elif _name in ['bootloader', 'lilo']:
                     self.assertEqual(10, cmd.writePriority, command_class)
                 elif _name in ['multipath']:
@@ -59,7 +49,7 @@ class WritePriority_TestCase(unittest.TestCase):
                 elif _name in ['snapshot']:
                     self.assertEqual(140, cmd.writePriority, command_class)
                 else:
-                    self.fail("Unknown writePriority for %s:%s" % (_name, command_class))
+                    self.assertEqual(0, cmd.writePriority, command_class)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The authconfig program is deprecated, so the authconfig command will
use the authconfig compatibility tool and the new authselect command
will use the authselect program.

Related: rhbz#1542968

**Depends on:** https://github.com/rhinstaller/anaconda/pull/1327