### PR TITLE
 Handle error message formatting in KickstartError

### DIFF
--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -42,7 +42,7 @@ from pykickstart.i18n import _
 
 import six
 import warnings
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.ko import KickstartObject
 from pykickstart.version import versionToString
 from pykickstart.parser import Packages
@@ -362,7 +362,7 @@ class KickstartHandler(KickstartObject):
         cmd = args[0]
 
         if cmd not in self.commands:
-            raise KickstartParseError(formatErrorMsg(lineno, msg=_("Unknown command: %s") % cmd), lineno=lineno)
+            raise KickstartParseError(_("Unknown command: %s") % cmd, lineno=lineno)
         elif self.commands[cmd] is not None:
             self.commands[cmd].currentCmd = cmd
             self.commands[cmd].currentLine = self.currentLine

--- a/pykickstart/commands/autopart.py
+++ b/pykickstart/commands/autopart.py
@@ -21,7 +21,7 @@ from pykickstart.base import KickstartCommand
 from pykickstart.version import versionToLongString, RHEL6, RHEL7, RHEL8
 from pykickstart.version import FC3, F9, F12, F16, F17, F18, F20, F21, F26
 from pykickstart.constants import AUTOPART_TYPE_BTRFS, AUTOPART_TYPE_LVM, AUTOPART_TYPE_LVM_THINP, AUTOPART_TYPE_PLAIN
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -44,7 +44,7 @@ class FC3_AutoPart(KickstartCommand):
 
     def parse(self, args):
         if len(args) > 0:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s does not take any arguments") % "autopart"), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command %s does not take any arguments") % "autopart", lineno=self.lineno)
 
         self.autopart = True
         return self
@@ -210,7 +210,7 @@ class RHEL6_AutoPart(F12_AutoPart):
         if conflicting_command:
             # allow for translation of the error message
             errorMsg = _("The %s and autopart commands can't be used at the same time") % conflicting_command
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         return retval
 
 
@@ -282,7 +282,7 @@ class F17_AutoPart(F16_AutoPart):
         if value.lower() in self.typeMap:
             return self.typeMap[value.lower()]
         else:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Invalid autopart type: %s") % value), lineno=self.lineno)
+            raise KickstartParseError(_("Invalid autopart type: %s") % value, lineno=self.lineno)
 
     def _getParser(self):
         op = F16_AutoPart._getParser(self)
@@ -366,7 +366,7 @@ class F20_AutoPart(F18_AutoPart):
         if conflicting_command:
             # allow for translation of the error message
             errorMsg = _("The %s and autopart commands can't be used at the same time") % conflicting_command
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         return retval
 
     def _getParser(self):
@@ -417,10 +417,10 @@ class F21_AutoPart(F20_AutoPart):
 
         # btrfs is not a valid filesystem type
         if self.fstype == "btrfs":
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("autopart --fstype=btrfs is not valid fstype, use --type=btrfs instead")), lineno=self.lineno)
+            raise KickstartParseError(_("autopart --fstype=btrfs is not valid fstype, use --type=btrfs instead"), lineno=self.lineno)
 
         if self._typeAsStr() == "btrfs" and self.fstype:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("autopart --fstype cannot be used with --type=btrfs")), lineno=self.lineno)
+            raise KickstartParseError(_("autopart --fstype cannot be used with --type=btrfs"), lineno=self.lineno)
 
         return retval
 
@@ -436,7 +436,7 @@ class F23_AutoPart(F21_AutoPart):
         if conflicting_command:
             # allow for translation of the error message
             errorMsg = _("The %s and autopart commands can't be used at the same time") % conflicting_command
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         return retval
 
@@ -477,7 +477,7 @@ class RHEL7_AutoPart(F21_AutoPart):
         if conflicting_command:
             # allow for translation of the error message
             errorMsg = _("The %s and autopart commands can't be used at the same time") % conflicting_command
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         return retval
 
@@ -540,8 +540,8 @@ class RHEL8_AutoPart(F26_AutoPart):
 
         # btrfs is no more supported
         if self._typeAsStr() == "btrfs":
-            raise KickstartParseError(formatErrorMsg(self.lineno,
-                    msg=_("autopart --type=btrfs is not supported")))
+            raise KickstartParseError(_("autopart --type=btrfs is not supported"),
+                                      lineno=self.lineno)
 
         return retval
 

--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -20,7 +20,7 @@
 from pykickstart.version import RHEL5, RHEL6
 from pykickstart.version import FC3, FC4, F8, F12, F14, F15, F17, F18, F19, F21
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser, commaSplit
 
 from pykickstart.i18n import _
@@ -319,7 +319,7 @@ class F17_Bootloader(F15_Bootloader):
         retval = F15_Bootloader.parse(self, args)
 
         if "," in retval.bootDrive:     # pylint: disable=no-member
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--boot-drive accepts only one argument")), lineno=self.lineno)
+            raise KickstartParseError(_("--boot-drive accepts only one argument"), lineno=self.lineno)
 
         return retval
 

--- a/pykickstart/commands/btrfs.py
+++ b/pykickstart/commands/btrfs.py
@@ -20,7 +20,7 @@
 #
 from pykickstart.version import F17, F23, RHEL8, versionToLongString
 from pykickstart.base import BaseData, KickstartCommand, DeprecatedCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -126,7 +126,7 @@ class F17_BTRFS(KickstartCommand):
             if value.lower() in self.levelMap:
                 return self.levelMap[value.lower()]
             else:
-                raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Invalid btrfs level: %s") % value), lineno=self.lineno)
+                raise KickstartParseError(_("Invalid btrfs level: %s") % value, lineno=self.lineno)
 
         op = KSOptionParser(prog="btrfs", description="""
                             Defines a BTRFS volume or subvolume. This command
@@ -212,21 +212,21 @@ class F17_BTRFS(KickstartCommand):
             data.format = False
 
         if not extra:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("btrfs must be given a mountpoint")), lineno=self.lineno)
+            raise KickstartParseError(_("btrfs must be given a mountpoint"), lineno=self.lineno)
         elif any(arg for arg in extra if arg.startswith("-")):
             mapping = {"command": "btrfs", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         data.mountpoint = extra[0]
         data.devices = extra[1:]
 
         if not any([data.devices, data.subvol]):
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("btrfs must be given a list of partitions")), lineno=self.lineno)
+            raise KickstartParseError(_("btrfs must be given a list of partitions"), lineno=self.lineno)
         elif not data.devices:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("btrfs subvol requires specification of parent volume")), lineno=self.lineno)
+            raise KickstartParseError(_("btrfs subvol requires specification of parent volume"), lineno=self.lineno)
 
         if data.subvol and not data.name:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("btrfs subvolume requires a name")), lineno=self.lineno)
+            raise KickstartParseError(_("btrfs subvolume requires a name"), lineno=self.lineno)
 
         # Check for duplicates in the data list.
         if data in self.dataList():
@@ -261,7 +261,7 @@ class F23_BTRFS(F17_BTRFS):
         data = F17_BTRFS.parse(self, args)
 
         if (data.preexist or not data.format) and data.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions with --noformat or --useexisting has no effect.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions with --noformat or --useexisting has no effect."), lineno=self.lineno)
 
         return data
 

--- a/pykickstart/commands/cdrom.py
+++ b/pykickstart/commands/cdrom.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -38,7 +38,7 @@ class FC3_Cdrom(KickstartCommand):
 
     def parse(self, args):
         if args:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s does not take any arguments") % self.currentCmd), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command %s does not take any arguments") % self.currentCmd, lineno=self.lineno)
 
         return self
 

--- a/pykickstart/commands/device.py
+++ b/pykickstart/commands/device.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import versionToLongString, FC3, F24
 from pykickstart.base import BaseData, DeprecatedCommand, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -112,10 +112,10 @@ class FC3_Device(KickstartCommand):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if len(extra) != 2:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("device command requires two arguments: module type and name")), lineno=self.lineno)
+            raise KickstartParseError(_("device command requires two arguments: module type and name"), lineno=self.lineno)
         elif any(arg for arg in extra if arg.startswith("-")):
             mapping = {"command": "device", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.moduleOpts = ns.moduleOpts
         self.type = extra[0]
@@ -141,10 +141,10 @@ class F8_Device(FC3_Device):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if len(extra) != 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("%(command)s command requires a single argument: %(argument)s") % {"command": "device", "argument": "module name"}), lineno=self.lineno)
+            raise KickstartParseError(_("%(command)s command requires a single argument: %(argument)s") % {"command": "device", "argument": "module name"}, lineno=self.lineno)
         elif any(arg for arg in extra if arg.startswith("-")):
             mapping = {"command": "device", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         dd = self.dataClass()   # pylint: disable=not-callable
         self.set_to_obj(ns, dd)

--- a/pykickstart/commands/displaymode.py
+++ b/pykickstart/commands/displaymode.py
@@ -21,7 +21,7 @@ from pykickstart.version import FC3, F26
 from pykickstart.base import KickstartCommand
 from pykickstart.constants import DISPLAY_MODE_CMDLINE, DISPLAY_MODE_GRAPHICAL, \
                                   DISPLAY_MODE_TEXT
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -61,7 +61,7 @@ class FC3_DisplayMode(KickstartCommand):
         elif self.currentCmd == "text":
             self.displayMode = DISPLAY_MODE_TEXT
         else:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unknown command %s") % self.currentCmd), lineno=self.lineno)
+            raise KickstartParseError(_("Unknown command %s") % self.currentCmd, lineno=self.lineno)
 
         return self
 
@@ -106,6 +106,6 @@ class F26_DisplayMode(FC3_DisplayMode):
 
         if self.currentCmd == "cmdline" and self.nonInteractive:
             msg = _("Kickstart command cmdline does not support --non-interactive parameter")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg), lineno=self.lineno)
+            raise KickstartParseError(msg, lineno=self.lineno)
 
         return self

--- a/pykickstart/commands/driverdisk.py
+++ b/pykickstart/commands/driverdisk.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, FC4, F12, F14
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -126,16 +126,16 @@ class FC3_DriverDisk(KickstartCommand):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if len(ns.partition) > 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one partition may be specified for driverdisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("Only one partition may be specified for driverdisk command."), lineno=self.lineno)
         elif extra:
             mapping = {"command": "driverdisk", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         if len(ns.partition) == 1 and ns.source:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one of --source and partition may be specified for driverdisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("Only one of --source and partition may be specified for driverdisk command."), lineno=self.lineno)
 
         if not ns.partition and not ns.source:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("One of --source or partition must be specified for driverdisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("One of --source or partition must be specified for driverdisk command."), lineno=self.lineno)
 
         ddd = self.dataClass()  # pylint: disable=not-callable
         self.set_to_obj(ns, ddd)
@@ -167,20 +167,20 @@ class FC4_DriverDisk(FC3_DriverDisk):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if len(ns.partition) > 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one partition may be specified for driverdisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("Only one partition may be specified for driverdisk command."), lineno=self.lineno)
         elif extra:
             mapping = {"command": "driverdisk", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         if len(ns.partition) == 1 and ns.source:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one of --source and partition may be specified for driverdisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("Only one of --source and partition may be specified for driverdisk command."), lineno=self.lineno)
         elif len(ns.partition) == 1 and ns.biospart:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one of --biospart and partition may be specified for driverdisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("Only one of --biospart and partition may be specified for driverdisk command."), lineno=self.lineno)
         elif ns.source and ns.biospart:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one of --biospart and --source may be specified for driverdisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("Only one of --biospart and --source may be specified for driverdisk command."), lineno=self.lineno)
 
         if not ns.partition and not ns.source and not ns.biospart:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("One of --source, --biospart, or partition must be specified for driverdisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("One of --source, --biospart, or partition must be specified for driverdisk command."), lineno=self.lineno)
 
         ddd = self.dataClass()  # pylint: disable=not-callable
         self.set_to_obj(ns, ddd)

--- a/pykickstart/commands/eula.py
+++ b/pykickstart/commands/eula.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import F20
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -62,9 +62,9 @@ class F20_Eula(KickstartCommand):
         self.set_to_self(ns)
 
         if extra:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s does not take any arguments") % "eula"), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command %s does not take any arguments") % "eula", lineno=self.lineno)
 
         if not self.agreed:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command eula expects the --agreed option")), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command eula expects the --agreed option"), lineno=self.lineno)
 
         return self

--- a/pykickstart/commands/harddrive.py
+++ b/pykickstart/commands/harddrive.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -85,6 +85,6 @@ class FC3_HardDrive(KickstartCommand):
 
         if self.biospart is None and self.partition is None or \
            self.biospart is not None and self.partition is not None:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("One of biospart or partition options must be specified.")), lineno=self.lineno)
+            raise KickstartParseError(_("One of biospart or partition options must be specified."), lineno=self.lineno)
 
         return self

--- a/pykickstart/commands/hmc.py
+++ b/pykickstart/commands/hmc.py
@@ -18,7 +18,7 @@
 # with the express permission of Red Hat, Inc.
 #
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 from pykickstart.version import RHEL7
 from pykickstart.i18n import _
@@ -44,7 +44,7 @@ class RHEL7_Hmc(KickstartCommand):
     def parse(self, args):
         if args:
             msg = _("Kickstart command %s does not take any arguments") % self.currentCmd
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg), lineno=self.lineno)
+            raise KickstartParseError(msg, lineno=self.lineno)
 
         return self
 

--- a/pykickstart/commands/ignoredisk.py
+++ b/pykickstart/commands/ignoredisk.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, F8, RHEL6
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.i18n import _
 from pykickstart.options import KSOptionParser, commaSplit
 
@@ -86,7 +86,7 @@ class F8_IgnoreDisk(FC3_IgnoreDisk):
             if self.onlyuse:
                 howmany += 1
             if howmany != 1:
-                raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("One of --drives or --only-use must be specified for ignoredisk command.")), lineno=self.lineno)
+                raise KickstartParseError(_("One of --drives or --only-use must be specified for ignoredisk command."), lineno=self.lineno)
 
 
         return retval
@@ -129,7 +129,7 @@ class RHEL6_IgnoreDisk(F8_IgnoreDisk):
         if self.interactive:
             howmany += 1
         if howmany != 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("One of --drives , --only-use , or --interactive must be specified for ignoredisk command.")), lineno=self.lineno)
+            raise KickstartParseError(_("One of --drives , --only-use , or --interactive must be specified for ignoredisk command."), lineno=self.lineno)
 
         if self.interactive:
             self.ignoredisk = []

--- a/pykickstart/commands/iscsiname.py
+++ b/pykickstart/commands/iscsiname.py
@@ -20,7 +20,7 @@
 #
 from pykickstart.version import FC6
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -58,7 +58,7 @@ class FC6_IscsiName(KickstartCommand):
 
         if extra:
             mapping = {"command": "iscsiname", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.iscsiname = _ns.iqn[0]
         return self

--- a/pykickstart/commands/key.py
+++ b/pykickstart/commands/key.py
@@ -20,7 +20,7 @@
 from pykickstart.version import RHEL5
 from pykickstart.base import KickstartCommand
 from pykickstart.constants import KS_INSTKEY_SKIP
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -58,10 +58,10 @@ class RHEL5_Key(KickstartCommand):
         if self.skip:
             self.key = KS_INSTKEY_SKIP
         elif len(extra) != 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s requires one argument") % "key"), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command %s requires one argument") % "key", lineno=self.lineno)
         elif any(arg for arg in extra if arg.startswith("-")):
             mapping = {"command": "key", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
         else:
             self.key = extra[0]
 

--- a/pykickstart/commands/keyboard.py
+++ b/pykickstart/commands/keyboard.py
@@ -20,7 +20,7 @@
 from textwrap import dedent
 from pykickstart.base import KickstartCommand
 from pykickstart.version import FC3, F18, versionToLongString
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser, commaSplit
 
 from pykickstart.i18n import _
@@ -53,10 +53,10 @@ class FC3_Keyboard(KickstartCommand):
         (_ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if len(_ns.kbd) != 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s requires one argument") % "keyboard"), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command %s requires one argument") % "keyboard", lineno=self.lineno)
         elif extra:
             mapping = {"command": "keyboard", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.keyboard = _ns.kbd[0]
         return self
@@ -161,14 +161,14 @@ class F18_Keyboard(FC3_Keyboard):
 
         if len(ns.kbd) > 1:
             message = _("A single argument is expected for the %s command") % "keyboard"
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=message), lineno=self.lineno)
+            raise KickstartParseError(message, lineno=self.lineno)
         elif extra:
             mapping = {"command": "keyboard", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
         elif not any([ns.kbd, self.vc_keymap, self.x_layouts]):
             message = _("One of --xlayouts, --vckeymap options with value(s) "
                         "or argument is expected for the keyboard command")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=message), lineno=self.lineno)
+            raise KickstartParseError(message, lineno=self.lineno)
 
         if ns.kbd:
             self._keyboard = ns.kbd[0]

--- a/pykickstart/commands/lang.py
+++ b/pykickstart/commands/lang.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, F19
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser, commaSplit
 
 from pykickstart.i18n import _
@@ -68,7 +68,7 @@ class FC3_Lang(KickstartCommand):
 
         if extra:
             mapping = {"command": "lang", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.set_to_self(ns)
         self.lang = ns.lang[0]

--- a/pykickstart/commands/langsupport.py
+++ b/pykickstart/commands/langsupport.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, FC5, versionToLongString
 from pykickstart.base import DeprecatedCommand, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.i18n import _
 from pykickstart.options import KSOptionParser
 
@@ -56,7 +56,7 @@ class FC3_LangSupport(KickstartCommand):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
         if any(arg for arg in extra if arg.startswith("-")):
             mapping = {"command": "langsupport", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.set_to_self(ns)
         self.supported = extra

--- a/pykickstart/commands/logging.py
+++ b/pykickstart/commands/logging.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC6
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -77,7 +77,7 @@ class FC6_Logging(KickstartCommand):
         self.set_to_self(ns)
 
         if self.port and not self.host:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Can't specify --port without --host.")), lineno=self.lineno)
+            raise KickstartParseError(_("Can't specify --port without --host."), lineno=self.lineno)
 
         self._level_provided = True
         return self

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -20,7 +20,7 @@
 from pykickstart.version import FC3, FC4, F9, F12, F14, F15, F17, F18, F20, F21
 from pykickstart.version import F23, RHEL5, RHEL6, RHEL7, RHEL8, versionToLongString
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser, commaSplit
 
 import warnings
@@ -428,7 +428,7 @@ class FC3_LogVol(KickstartCommand):
 
         if extra:
             mapping = {"command": "logvol", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         lvd = self.dataClass()  # pylint: disable=not-callable
         self.set_to_obj(ns, lvd)
@@ -584,21 +584,21 @@ class RHEL6_LogVol(F12_LogVol):
         # due to the hard to debug behavior their combination introduces
         if self.handler.autopart.seen:
             errorMsg = _("The logvol and autopart commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         if retval.thin_volume and retval.thin_pool:
             errorMsg = _("--thin and --thinpool cannot both be specified for "
                          "the same logvol")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         if retval.thin_volume and not retval.pool_name:
             errorMsg = _("--thin requires --poolname to specify pool name")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         if (retval.chunk_size or retval.metadata_size) and \
            not retval.thin_pool:
             errorMsg = _("--chunksize and --metadatasize are for thin pools only")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         return retval
 
@@ -641,10 +641,10 @@ class F17_LogVol(F15_LogVol):
         retval = F15_LogVol.parse(self, args)
 
         if retval.resize and not retval.preexist:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--resize can only be used in conjunction with --useexisting")), lineno=self.lineno)
+            raise KickstartParseError(_("--resize can only be used in conjunction with --useexisting"), lineno=self.lineno)
 
         if retval.resize and not retval.size:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--resize requires --size to indicate new size")), lineno=self.lineno)
+            raise KickstartParseError(_("--resize requires --size to indicate new size"), lineno=self.lineno)
 
         return retval
 
@@ -697,41 +697,35 @@ class F20_LogVol(F18_LogVol):
         retval = F18_LogVol.parse(self, args)
 
         if retval.thin_volume and retval.thin_pool:
-            err = formatErrorMsg(self.lineno,
-                                 msg=_("--thin and --thinpool cannot both be "
-                                       "specified for the same logvol"))
+            err = _("--thin and --thinpool cannot both be specified for the same logvol")
             raise KickstartParseError(err, lineno=self.lineno)
 
         if retval.thin_volume and not retval.pool_name:
-            err = formatErrorMsg(self.lineno,
-                                 msg=_("--thin requires --poolname to specify "
-                                       "pool name"))
+            err = _("--thin requires --poolname to specify pool name")
             raise KickstartParseError(err, lineno=self.lineno)
 
         if (retval.chunk_size or retval.metadata_size) and \
            not retval.thin_pool:
-            err = formatErrorMsg(self.lineno,
-                                 msg=_("--chunksize and --metadatasize are "
-                                       "for thin pools only"))
+            err = _("--chunksize and --metadatasize are for thin pools only")
             raise KickstartParseError(err, lineno=self.lineno)
 
         # the logvol command can't be used together with the autopart command
         # due to the hard to debug behavior their combination introduces
         if self.handler.autopart.seen:
             errorMsg = _("The logvol and autopart commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         # the same applies to the 'mount' command
         if hasattr(self.handler, "mount") and self.handler.mount.seen:
             errorMsg = _("The logvol and mount commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         if not retval.preexist and not retval.percent and not retval.size and not retval.recommended and not retval.hibernation:
             errorMsg = _("No size given for logical volume. Use one of --useexisting, --noformat, --size, --percent, or --hibernation.")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         if retval.percent is not None and (retval.percent < 0 or retval.percent > 100):
             errorMsg = _("Percentage must be between 0 and 100.")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         return retval
 
@@ -751,9 +745,7 @@ class F21_LogVol(F20_LogVol):
         retval = F20_LogVol.parse(self, args)
 
         if retval.size and retval.percent:
-            err = formatErrorMsg(self.lineno,
-                                 msg=_("--size and --percent cannot both be "
-                                       "specified for the same logvol"))
+            err = _("--size and --percent cannot both be specified for the same logvol")
             raise KickstartParseError(err, lineno=self.lineno)
 
         return retval
@@ -778,10 +770,10 @@ class RHEL7_LogVol(F21_LogVol):
         retval = F21_LogVol.parse(self, args)
 
         if not retval.format and retval.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions with --noformat has no effect.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions with --noformat has no effect."), lineno=self.lineno)
 
         if retval.fsprofile and retval.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions and --fsprofile cannot be used together.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions and --fsprofile cannot be used together."), lineno=self.lineno)
 
         return retval
 
@@ -815,30 +807,30 @@ class F23_LogVol(F21_LogVol):
 
         if retval.cache_size or retval.cache_mode or retval.cache_pvs:
             if retval.preexist:
-                err = formatErrorMsg(self.lineno, msg=_("Adding a cache to an existing logical volume is not supported"))
+                err = _("Adding a cache to an existing logical volume is not supported")
                 raise KickstartParseError(err, lineno=self.lineno)
 
             if retval.thin_volume:
-                err = formatErrorMsg(self.lineno, msg=_("Thin volumes cannot be cached"))
+                err = _("Thin volumes cannot be cached")
                 raise KickstartParseError(err, lineno=self.lineno)
 
             if not retval.cache_pvs:
-                err = formatErrorMsg(self.lineno, msg=_("Cache needs to have a list of (fast) PVs specified"))
+                err = _("Cache needs to have a list of (fast) PVs specified")
                 raise KickstartParseError(err, lineno=self.lineno)
 
             if not retval.cache_size:
-                err = formatErrorMsg(self.lineno, msg=_("Cache needs to have size specified"))
+                err = _("Cache needs to have size specified")
                 raise KickstartParseError(err, lineno=self.lineno)
 
             if retval.cache_mode and retval.cache_mode not in ("writeback", "writethrough"):
-                err = formatErrorMsg(self.lineno, msg=_("Invalid cache mode given: %s") % retval.cache_mode)
+                err = _("Invalid cache mode given: %s") % retval.cache_mode
                 raise KickstartParseError(err, lineno=self.lineno)
 
         if not retval.format and retval.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions with --noformat has no effect.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions with --noformat has no effect."), lineno=self.lineno)
 
         if retval.fsprofile and retval.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions and --fsprofile cannot be used together.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions and --fsprofile cannot be used together."), lineno=self.lineno)
 
         return retval
 
@@ -849,7 +841,7 @@ class RHEL8_LogVol(F23_LogVol):
     def parse(self, args):
         retval = F23_LogVol.parse(self, args)
         if retval.fstype == "btrfs":
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Btrfs file system is not supported")))
+            raise KickstartParseError(_("Btrfs file system is not supported"), lineno=self.lineno)
         return retval
 
     def _getParser(self):

--- a/pykickstart/commands/mount.py
+++ b/pykickstart/commands/mount.py
@@ -19,7 +19,7 @@
 #
 
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 from pykickstart.version import F27
 
@@ -166,13 +166,13 @@ class F27_Mount(KickstartCommand):
             # allow for translation of the error message
             errorMsg = _("The '%s' and 'mount' commands can't be used at the same time") % \
                          conflicting_command
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if extra:
             mapping = {"command": "mount", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         md = self.dataClass()  # pylint: disable=not-callable
         self.set_to_obj(ns, md)
@@ -181,10 +181,10 @@ class F27_Mount(KickstartCommand):
         md.mount_point = ns.mntpoint[0]
 
         if md.mount_point.lower() != "none" and not md.mount_point.startswith("/"):
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Invalid mount point '%s' given") % md.mount_point), lineno=self.lineno)
+            raise KickstartParseError(_("Invalid mount point '%s' given") % md.mount_point, lineno=self.lineno)
 
         if md.reformat is False and md.mkfs_opts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("'--mkfsoptions' requires --reformat")), lineno=self.lineno)
+            raise KickstartParseError(_("'--mkfsoptions' requires --reformat"), lineno=self.lineno)
 
         # The semantics is as follows:
         #   --reformat          -> just reformat with the same format as existing

--- a/pykickstart/commands/mouse.py
+++ b/pykickstart/commands/mouse.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import versionToLongString, RHEL3, FC3
 from pykickstart.base import DeprecatedCommand, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -62,10 +62,10 @@ class RHEL3_Mouse(KickstartCommand):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if len(extra) != 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s requires one argument") % "mouse"), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command %s requires one argument") % "mouse", lineno=self.lineno)
         elif any(arg for arg in extra if arg.startswith("-")):
             mapping = {"command": "mouse", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.set_to_self(ns)
         self.mouse = extra[0]

--- a/pykickstart/commands/multipath.py
+++ b/pykickstart/commands/multipath.py
@@ -20,7 +20,7 @@
 #
 from pykickstart.version import versionToLongString, FC6, F24
 from pykickstart.base import BaseData, DeprecatedCommand, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -95,7 +95,7 @@ class FC6_MultiPath(KickstartCommand):
             for path in mpath.paths:
                 if path.device == dd.device:
                     mapping = {"device": path.device, "multipathdev": path.mpdev}
-                    raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Device '%(device)s' is already used in multipath '%(multipathdev)s'") % mapping), lineno=self.lineno)
+                    raise KickstartParseError(_("Device '%(device)s' is already used in multipath '%(multipathdev)s'") % mapping, lineno=self.lineno)
             if mpath.name == dd.mpdev:
                 parent = x
 

--- a/pykickstart/commands/network.py
+++ b/pykickstart/commands/network.py
@@ -23,7 +23,7 @@ from pykickstart.version import versionToLongString, RHEL4, RHEL5, RHEL6, RHEL7
 from pykickstart.version import FC3, FC4, FC6, F8, F9, F16, F19, F20, F21, F22, F25, F27
 from pykickstart.constants import BOOTPROTO_BOOTP, BOOTPROTO_DHCP, BOOTPROTO_IBFT, BOOTPROTO_QUERY, BOOTPROTO_STATIC, BIND_TO_MAC
 from pykickstart.options import KSOptionParser, ksboolean
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 
 import warnings
 from pykickstart.i18n import _
@@ -743,13 +743,13 @@ class F22_Network(F21_Network):
 
         if retval.bridgeopts:
             if not retval.bridgeslaves:
-                msg = formatErrorMsg(self.lineno, msg=_("Option --bridgeopts requires --bridgeslaves to be specified"))
+                msg = _("Option --bridgeopts requires --bridgeslaves to be specified")
                 raise KickstartParseError(msg, lineno=self.lineno)
             opts = retval.bridgeopts.split(",")
             for opt in opts:
                 _key, _sep, value = opt.partition("=")
                 if not value or "=" in value:
-                    msg = formatErrorMsg(self.lineno, msg=_("Bad format of --bridgeopts, expecting key=value options separated by ','"))
+                    msg = _("Bad format of --bridgeopts, expecting key=value options separated by ','")
                     raise KickstartParseError(msg, lineno=self.lineno)
 
         return retval
@@ -831,7 +831,7 @@ class F27_Network(F25_Network):
 
         if retval.bindto == BIND_TO_MAC:
             if retval.vlanid and not retval.bondopts:
-                msg = formatErrorMsg(self.lineno, msg=_("--bindto=%s is not supported for this type of device") % BIND_TO_MAC)
+                msg = _("--bindto=%s is not supported for this type of device") % BIND_TO_MAC
                 raise KickstartParseError(msg, lineno=self.lineno)
 
         return retval
@@ -1042,22 +1042,22 @@ class RHEL7_Network(F21_Network):
         error_message = validate_network_interface_name(retval.interfacename)
         # something is wrong with the interface name
         if error_message:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message), lineno=self.lineno)
+            raise KickstartParseError(error_message, lineno=self.lineno)
 
         if retval.bridgeopts:
             if not retval.bridgeslaves:
-                msg = formatErrorMsg(self.lineno, msg=_("Option --bridgeopts requires --bridgeslaves to be specified"))
+                msg = _("Option --bridgeopts requires --bridgeslaves to be specified")
                 raise KickstartParseError(msg, lineno=self.lineno)
             opts = retval.bridgeopts.split(",")
             for opt in opts:
                 _key, _sep, value = opt.partition("=")
                 if not value or "=" in value:
-                    msg = formatErrorMsg(self.lineno, msg=_("Bad format of --bridgeopts, expecting key=value options separated by ','"))
+                    msg = _("Bad format of --bridgeopts, expecting key=value options separated by ','")
                     raise KickstartParseError(msg, lineno=self.lineno)
 
         if retval.bindto == BIND_TO_MAC:
             if retval.vlanid and not retval.bondopts:
-                msg = formatErrorMsg(self.lineno, msg=_("--bindto=%s is not supported for this type of device") % BIND_TO_MAC)
+                msg = _("--bindto=%s is not supported for this type of device") % BIND_TO_MAC
                 raise KickstartParseError(msg, lineno=self.lineno)
 
         return retval

--- a/pykickstart/commands/ostreesetup.py
+++ b/pykickstart/commands/ostreesetup.py
@@ -17,7 +17,7 @@
 #
 from pykickstart.version import F21
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 class F21_OSTreeSetup(KickstartCommand):
@@ -81,7 +81,7 @@ class F21_OSTreeSetup(KickstartCommand):
             self.remote = self.osname
 
         if not self.url.startswith(("file:", "http:", "https:")):
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg="ostree repos must use file, HTTP or HTTPS protocol."), lineno=self.lineno)
+            raise KickstartParseError("ostree repos must use file, HTTP or HTTPS protocol.", lineno=self.lineno)
 
         return self
 

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -20,7 +20,7 @@
 from pykickstart.version import RHEL5, RHEL6, RHEL8, versionToLongString
 from pykickstart.version import FC3, FC4, F9, F11, F12, F14, F17, F18, F23
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -404,7 +404,7 @@ class FC3_Partition(KickstartCommand):
 
         if extra:
             mapping = {"command": "partition", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         pd = self.dataClass()   # pylint: disable=not-callable
         self.set_to_obj(ns, pd)
@@ -545,7 +545,7 @@ class RHEL6_Partition(F12_Partition):
         # due to the hard to debug behavior their combination introduces
         if self.handler.autopart.seen:
             errorMsg = _("The part/partition and autopart commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         return retval
 
 class F14_Partition(F12_Partition):
@@ -576,10 +576,10 @@ class F17_Partition(F14_Partition):
         retval = F14_Partition.parse(self, args)
 
         if retval.resize and not retval.onPart:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--resize can only be used in conjunction with --onpart")), lineno=self.lineno)
+            raise KickstartParseError(_("--resize can only be used in conjunction with --onpart"), lineno=self.lineno)
 
         if retval.resize and not retval.size:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--resize requires --size to specify new size")), lineno=self.lineno)
+            raise KickstartParseError(_("--resize requires --size to specify new size"), lineno=self.lineno)
 
         return retval
 
@@ -611,17 +611,17 @@ class F20_Partition(F18_Partition):
         # due to the hard to debug behavior their combination introduces
         if self.handler.autopart.seen:
             errorMsg = _("The part/partition and autopart commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         # the same applies to the 'mount' command
         if hasattr(self.handler, "mount") and self.handler.mount.seen:
             errorMsg = _("The part/partition and mount commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         # when using tmpfs, grow is not suported
         if retval.fstype == "tmpfs":
             if retval.grow or retval.maxSizeMB != 0:
                 errorMsg = _("The --fstype=tmpfs option can't be used together with --grow or --maxsize")
-                raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+                raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         return retval
 
@@ -647,10 +647,10 @@ class F23_Partition(F20_Partition):
         retval = F20_Partition.parse(self, args)
 
         if not retval.format and retval.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions with --noformat has no effect.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions with --noformat has no effect."), lineno=self.lineno)
 
         if retval.fsprofile and retval.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions and --fsprofile cannot be used together.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions and --fsprofile cannot be used together."), lineno=self.lineno)
 
         return retval
 
@@ -664,7 +664,7 @@ class RHEL8_Partition(F23_Partition):
     def parse(self, args):
         retval = F23_Partition.parse(self, args)
         if retval.mountpoint.startswith("btrfs.") or retval.fstype == "btrfs":
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Btrfs file system is not supported")))
+            raise KickstartParseError(_("Btrfs file system is not supported"), lineno=self.lineno)
         return retval
 
     def _getParser(self):

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -21,7 +21,7 @@ from textwrap import dedent
 from pykickstart.version import versionToLongString, RHEL5, RHEL6, FC3, FC4, FC5
 from pykickstart.version import F7, F9, F12, F13, F14, F15, F18, F23, F25, RHEL8
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -313,7 +313,7 @@ class FC3_Raid(KickstartCommand):
             if value.upper() in self.levelMap:
                 return self.levelMap[value.upper()]
             else:
-                raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Invalid raid level: %s") % value), lineno=self.lineno)
+                raise KickstartParseError(_("Invalid raid level: %s") % value, lineno=self.lineno)
 
         op = KSOptionParser(prog="raid", description="""
                             Assembles a software RAID device.""",
@@ -390,7 +390,7 @@ class FC3_Raid(KickstartCommand):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
         if any(arg for arg in extra if arg.startswith("-")):
             mapping = {"command": "raid", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         # because positional argumnets with variable number of values
         # don't parse very well
@@ -403,9 +403,9 @@ class FC3_Raid(KickstartCommand):
 
         assert len(ns.mntpoint) == 1
         if not ns.partitions and not ns.preexist:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Partitions required for %s") % "raid"), lineno=self.lineno)
+            raise KickstartParseError(_("Partitions required for %s") % "raid", lineno=self.lineno)
         elif ns.partitions and ns.preexist:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Members may not be specified for preexisting RAID device")), lineno=self.lineno)
+            raise KickstartParseError(_("Members may not be specified for preexisting RAID device"), lineno=self.lineno)
 
         rd = self.dataClass()   # pylint: disable=not-callable
         self.set_to_obj(ns, rd)
@@ -426,10 +426,10 @@ class FC3_Raid(KickstartCommand):
             warnings.warn(_("A RAID device with the name %s has already been defined.") % rd.device)
 
         if not rd.preexist and not rd.level:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg="RAID Partition defined without RAID level"), lineno=self.lineno)
+            raise KickstartParseError("RAID Partition defined without RAID level", lineno=self.lineno)
 
         if rd.preexist and rd.device == "":
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg="Device required for preexisting RAID device"), lineno=self.lineno)
+            raise KickstartParseError("Device required for preexisting RAID device", lineno=self.lineno)
 
         return rd
 
@@ -606,7 +606,7 @@ class RHEL6_Raid(F13_Raid):
         # due to the hard to debug behavior their combination introduces
         if self.handler.autopart.seen:
             errorMsg = _("The raid and autopart commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         return retval
 
 class F14_Raid(F13_Raid):
@@ -660,11 +660,11 @@ class F20_Raid(F19_Raid):
         # due to the hard to debug behavior their combination introduces
         if self.handler.autopart.seen:
             errorMsg = _("The raid and autopart commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         # the same applies to the 'mount' command
         if hasattr(self.handler, "mount") and self.handler.mount.seen:
             errorMsg = _("The raid and mount commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         return retval
 
 class F23_Raid(F20_Raid):
@@ -687,10 +687,10 @@ class F23_Raid(F20_Raid):
         retval = F20_Raid.parse(self, args)
 
         if not retval.format and retval.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions with --noformat has no effect.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions with --noformat has no effect."), lineno=self.lineno)
 
         if retval.fsprofile and retval.mkfsopts:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("--mkfsoptions and --fsprofile cannot be used together.")), lineno=self.lineno)
+            raise KickstartParseError(_("--mkfsoptions and --fsprofile cannot be used together."), lineno=self.lineno)
 
         return retval
 
@@ -716,7 +716,7 @@ class RHEL8_Raid(F25_Raid):
     def parse(self, args):
         retval = F25_Raid.parse(self, args)
         if retval.fstype == "btrfs":
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Btrfs file system is not supported")))
+            raise KickstartParseError(_("Btrfs file system is not supported"), lineno=self.lineno)
         return retval
 
     def _getParser(self):

--- a/pykickstart/commands/realm.py
+++ b/pykickstart/commands/realm.py
@@ -20,7 +20,7 @@
 from pykickstart.version import F19
 from pykickstart.base import KickstartCommand
 from pykickstart.options import KSOptionParser
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 
 import getopt
 import pipes
@@ -40,15 +40,15 @@ class F19_Realm(KickstartCommand):
 
     def _parseArguments(self, string):
         if self.join_realm:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("The realm command 'join' should only be specified once")), lineno=self.lineno)
+            raise KickstartParseError(_("The realm command 'join' should only be specified once"), lineno=self.lineno)
         args = shlex.split(string)
         if not args:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Missing realm command arguments")), lineno=self.lineno)
+            raise KickstartParseError(_("Missing realm command arguments"), lineno=self.lineno)
         command = args.pop(0)
         if command == "join":
             self._parseJoin(args)
         else:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unsupported realm '%s' command") % command), lineno=self.lineno)
+            raise KickstartParseError(_("Unsupported realm '%s' command") % command, lineno=self.lineno)
 
     def _parseJoin(self, args):
         try:
@@ -60,10 +60,10 @@ class F19_Realm(KickstartCommand):
                                                        "no-password",
                                                        "computer-ou="))
         except getopt.GetoptError as ex:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Invalid realm arguments: %s") % ex), lineno=self.lineno)
+            raise KickstartParseError(_("Invalid realm arguments: %s") % ex, lineno=self.lineno)
 
         if len(remaining) != 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Specify only one realm to join")), lineno=self.lineno)
+            raise KickstartParseError(_("Specify only one realm to join"), lineno=self.lineno)
 
         # Parse successful, just use this as the join command
         self.join_realm = remaining[0]

--- a/pykickstart/commands/repo.py
+++ b/pykickstart/commands/repo.py
@@ -21,7 +21,7 @@ from textwrap import dedent
 from pykickstart.version import versionToLongString
 from pykickstart.version import FC6, F8, F11, F13, F14, F15, F21, F27
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartError, KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartError, KickstartParseError
 from pykickstart.options import KSOptionParser, commaSplit, ksboolean
 
 import warnings
@@ -253,10 +253,10 @@ class FC6_Repo(KickstartCommand):
                         if getattr(ns, attr, None)]
         if self.urlRequired and not used_options:
             mapping = {"options_list": ", ".join((opt for attr, opt in self.exclusive_required_options))}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("One of -%(options_list)s options must be specified for repo command.") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("One of -%(options_list)s options must be specified for repo command.") % mapping, lineno=self.lineno)
         if len(used_options) > 1:
             mapping = {"options_list": ", ".join((opt for opt in used_options))}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one of %(options_list)s options may be specified for repo command.") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Only one of %(options_list)s options may be specified for repo command.") % mapping, lineno=self.lineno)
 
         rd = self.dataClass()   # pylint: disable=not-callable
         self.set_to_obj(ns, rd)
@@ -310,7 +310,7 @@ class F8_Repo(FC6_Repo):
 
     def methodToRepo(self):
         if not self.handler.method.url:
-            raise KickstartError(formatErrorMsg(self.handler.method.lineno, msg=_("Method must be a url to be added to the repo list.")))
+            raise KickstartError(_("Method must be a url to be added to the repo list."), lineno=self.handler.method.lineno)
         reponame = "ks-method-url"
         repourl = self.handler.method.url
         rd = self.handler.RepoData(name=reponame, baseurl=repourl)

--- a/pykickstart/commands/reqpart.py
+++ b/pykickstart/commands/reqpart.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import F23
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -77,11 +77,11 @@ class F23_ReqPart(KickstartCommand):
         if self.handler.autopart.seen:
             errorMsg = _("The %s and reqpart commands can't be used at the same time") % \
                          "autopart"
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         # the same applies to the 'mount' command
         if hasattr(self.handler, "mount") and self.handler.mount.seen:
             errorMsg = _("The mount and reqpart commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
 
         ns = self.op.parse_args(args=args, lineno=self.lineno)
         self.set_to_self(ns)

--- a/pykickstart/commands/rescue.py
+++ b/pykickstart/commands/rescue.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import F10
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -74,7 +74,7 @@ class F10_Rescue(KickstartCommand):
         ns = self.op.parse_args(args=args, lineno=self.lineno)
 
         if ns.nomount and ns.romount:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one of --nomount and --romount may be specified for rescue command.")), lineno=self.lineno)
+            raise KickstartParseError(_("Only one of --nomount and --romount may be specified for rescue command."), lineno=self.lineno)
 
         self.set_to_self(ns)
         self.rescue = True

--- a/pykickstart/commands/rootpw.py
+++ b/pykickstart/commands/rootpw.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, F8
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -82,10 +82,10 @@ class FC3_RootPw(KickstartCommand):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if not ns.password:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("A single argument is expected for the %s command") % "rootpw"), lineno=self.lineno)
+            raise KickstartParseError(_("A single argument is expected for the %s command") % "rootpw", lineno=self.lineno)
         elif extra:
             mapping = {"command": "rootpw", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.set_to_self(ns)
         return self
@@ -139,10 +139,10 @@ class F18_RootPw(F8_RootPw):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if not (ns.password or ns.lock):
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("A single argument is expected for the %s command") % "rootpw"), lineno=self.lineno)
+            raise KickstartParseError(_("A single argument is expected for the %s command") % "rootpw", lineno=self.lineno)
         elif extra:
             mapping = {"command": "rootpw", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.set_to_self(ns)
         return self

--- a/pykickstart/commands/services.py
+++ b/pykickstart/commands/services.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC6
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser, commaSplit
 
 from pykickstart.i18n import _
@@ -73,6 +73,6 @@ class FC6_Services(KickstartCommand):
         self.set_to_self(ns)
 
         if not (self.disabled or self.enabled):
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("One of --disabled or --enabled must be provided.")), lineno=self.lineno)
+            raise KickstartParseError(_("One of --disabled or --enabled must be provided."), lineno=self.lineno)
 
         return self

--- a/pykickstart/commands/snapshot.py
+++ b/pykickstart/commands/snapshot.py
@@ -19,7 +19,7 @@
 #
 
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 from pykickstart.constants import SNAPSHOT_WHEN_POST_INSTALL, SNAPSHOT_WHEN_PRE_INSTALL
 from pykickstart.version import F26
@@ -87,8 +87,8 @@ class F26_Snapshot(KickstartCommand):
         if value.lower() in self.whenMap:
             return self.whenMap[value.lower()]
         else:
-            msg=_("Invalid snapshot when parameter: %s") % value
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg), lineno=self.lineno)
+            msg = _("Invalid snapshot when parameter: %s") % value
+            raise KickstartParseError(msg, lineno=self.lineno)
 
     def _getParser(self):
         op = KSOptionParser(prog="snapshot", version=F26, description="""
@@ -112,10 +112,10 @@ class F26_Snapshot(KickstartCommand):
 
         if len(extra) == 0:
             msg = _("Snapshot origin must be specified!")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg), lineno=self.lineno)
+            raise KickstartParseError(msg, lineno=self.lineno)
         elif len(extra) > 1:
             msg = _("Snapshot origin can be specified only once!")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg), lineno=self.lineno)
+            raise KickstartParseError(msg, lineno=self.lineno)
 
         snap_data = self.dataClass()   # pylint: disable=not-callable
         self.set_to_obj(ns, snap_data)
@@ -125,21 +125,21 @@ class F26_Snapshot(KickstartCommand):
         # Check for duplicates
         if snap_data.name in [snap.name for snap in self.dataList()]:
             msg = (_("Snapshot with the name %s has been already defined!") % snap_data.name)
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg), lineno=self.lineno)
+            raise KickstartParseError(msg, lineno=self.lineno)
 
         if snap_data.when is None:
             msg = _("Snapshot \"when\" parameter must be specified!")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg), lineno=self.lineno)
+            raise KickstartParseError(msg, lineno=self.lineno)
 
         groups = snap_data.origin.split('/')
         if len(groups) != 2 or len(groups[0]) == 0 or len(groups[1]) == 0:
             msg = (_("Snapshot origin %s must be specified by VG/LV!") % snap_data.origin)
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg), lineno=self.lineno)
+            raise KickstartParseError(msg, lineno=self.lineno)
 
         # Check if value in a '--when' param is valid
         if snap_data.when != "" and snap_data.when not in self.whenMap.values():
             msg = (_("Snapshot when param must have one of these values %s!") % self.whenMap.keys())
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=msg), lineno=self.lineno)
+            raise KickstartParseError(msg, lineno=self.lineno)
         return snap_data
 
     def dataList(self):

--- a/pykickstart/commands/sshkey.py
+++ b/pykickstart/commands/sshkey.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import F22
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 import warnings
 
@@ -99,7 +99,7 @@ class F22_SshKey(KickstartCommand):
 
         if extra:
             mapping = {"command": "sshkey", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.set_to_obj(ns, ud)
         ud.key = ns.sshkey[0]

--- a/pykickstart/commands/sshpw.py
+++ b/pykickstart/commands/sshpw.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import F13, F24
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 import warnings
 
@@ -157,10 +157,10 @@ class F13_SshPw(KickstartCommand):
         (ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if not ns.password:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("A single argument is expected for the %s command") % "sshpw"), lineno=self.lineno)
+            raise KickstartParseError(_("A single argument is expected for the %s command") % "sshpw", lineno=self.lineno)
         if extra:
             mapping = {"command": "sshpw", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.set_to_obj(ns, ud)
         ud.password = " ".join(ns.password)

--- a/pykickstart/commands/timezone.py
+++ b/pykickstart/commands/timezone.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, FC6, F18
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser, commaSplit
 
 from pykickstart.i18n import _
@@ -78,7 +78,7 @@ class FC3_Timezone(KickstartCommand):
 
         if extra:
             mapping = {"command": "timezone", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
         self.timezone = ns.timezone[0]
         return self
@@ -167,7 +167,7 @@ class F18_Timezone(FC6_Timezone):
         self.ntpservers = list(set(self.ntpservers))
 
         if self.ntpservers and self.nontp:
-            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
+            msg = _("Options --nontp and --ntpservers are mutually exclusive")
             raise KickstartParseError(msg, lineno=self.lineno)
 
         return self
@@ -183,7 +183,7 @@ class F23_Timezone(F18_Timezone):
         FC6_Timezone.parse(self, args)
 
         if self.ntpservers and self.nontp:
-            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
+            msg = _("Options --nontp and --ntpservers are mutually exclusive")
             raise KickstartParseError(msg, lineno=self.lineno)
 
         return self
@@ -264,7 +264,7 @@ class RHEL7_Timezone(F18_Timezone):
         # so throw an error when we see it (it might even be an indication of an incorrect machine generated kickstart)
         if not args:
             error_message = _("At least one option and/or an argument are expected for the  %s command") % "timezone"
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message), lineno=self.lineno)
+            raise KickstartParseError(error_message, lineno=self.lineno)
 
         # To be able to support the timezone command being used without
         # a timezone specification:
@@ -277,10 +277,10 @@ class RHEL7_Timezone(F18_Timezone):
             self.timezone = ns.timezone[0]
         elif len(ns.timezone) > 1:
             error_message = _("One or zero arguments are expected for the %s command") % "timezone"
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message), lineno=self.lineno)
+            raise KickstartParseError(error_message, lineno=self.lineno)
 
         if self.ntpservers and self.nontp:
-            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
+            msg = _("Options --nontp and --ntpservers are mutually exclusive")
             raise KickstartParseError(msg, lineno=self.lineno)
 
         return self
@@ -339,7 +339,7 @@ class F25_Timezone(F23_Timezone):
         # so throw an error when we see it (it might even be an indication of an incorrect machine generated kickstart)
         if not args:
             error_message = _("At least one option and/or an argument are expected for the  %s command") % "timezone"
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message), lineno=self.lineno)
+            raise KickstartParseError(error_message, lineno=self.lineno)
 
         # To be able to support the timezone command being used without
         # a timezone specification:
@@ -352,10 +352,10 @@ class F25_Timezone(F23_Timezone):
             self.timezone = ns.timezone[0]
         elif len(ns.timezone) > 1:
             error_message = _("One or zero arguments are expected for the %s command") % "timezone"
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=error_message), lineno=self.lineno)
+            raise KickstartParseError(error_message, lineno=self.lineno)
 
         if self.ntpservers and self.nontp:
-            msg = formatErrorMsg(self.lineno, msg=_("Options --nontp and --ntpservers are mutually exclusive"))
+            msg = _("Options --nontp and --ntpservers are mutually exclusive")
             raise KickstartParseError(msg, lineno=self.lineno)
 
         return self

--- a/pykickstart/commands/updates.py
+++ b/pykickstart/commands/updates.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import F7
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -61,10 +61,10 @@ class F7_Updates(KickstartCommand):
         (_ns, extra) = self.op.parse_known_args(args=args, lineno=self.lineno)
 
         if len(_ns.updates) > 1:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %s only takes one argument") % "updates"), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command %s only takes one argument") % "updates", lineno=self.lineno)
         elif extra:
             mapping = {"command": "updates", "options": extra}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Unexpected arguments to %(command)s command: %(options)s") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
         elif not _ns.updates:
             self.url = "floppy"
         else:

--- a/pykickstart/commands/upgrade.py
+++ b/pykickstart/commands/upgrade.py
@@ -20,7 +20,7 @@
 from textwrap import dedent
 from pykickstart.version import versionToLongString, FC3, F11, F20
 from pykickstart.base import DeprecatedCommand, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -101,7 +101,7 @@ class F11_Upgrade(FC3_Upgrade):
         ns = self.op.parse_args(args=args, lineno=self.lineno)
 
         if ns.root_device == "":
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Kickstart command %(command)s does not accept empty parameter %(parameter)s") % {"command": "upgrade", "parameter": "--root-device"}), lineno=self.lineno)
+            raise KickstartParseError(_("Kickstart command %(command)s does not accept empty parameter %(parameter)s") % {"command": "upgrade", "parameter": "--root-device"}, lineno=self.lineno)
         else:
             self.root_device = ns.root_device
 

--- a/pykickstart/commands/url.py
+++ b/pykickstart/commands/url.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, F13, F14, F18, F27
 from pykickstart.base import KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 from pykickstart.i18n import _
@@ -191,10 +191,10 @@ class F18_Url(F14_Url):
                         if getattr(ns, attr, None)]
         if len(used_options) == 0:
             mapping = {"options_list": ", ".join((opt for attr, opt in self.exclusive_required_options))}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("One of -%(options_list)s options must be specified for url command.") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("One of -%(options_list)s options must be specified for url command.") % mapping, lineno=self.lineno)
         if len(used_options) > 1:
             mapping = {"options_list": ", ".join((opt for opt in used_options))}
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Only one of %(options_list)s options may be specified for url command.") % mapping), lineno=self.lineno)
+            raise KickstartParseError(_("Only one of %(options_list)s options may be specified for url command.") % mapping, lineno=self.lineno)
 
         return retval
 

--- a/pykickstart/commands/volgroup.py
+++ b/pykickstart/commands/volgroup.py
@@ -19,7 +19,7 @@
 #
 from pykickstart.version import FC3, F16, F21
 from pykickstart.base import BaseData, KickstartCommand
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 
 import warnings
@@ -164,12 +164,12 @@ class FC3_VolGroup(KickstartCommand):
         vg.lineno = self.lineno
 
         if not ns.name:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("volgroup must be given a VG name")), lineno=self.lineno)
+            raise KickstartParseError(_("volgroup must be given a VG name"), lineno=self.lineno)
 
         if not any([ns.partitions, ns.preexist]):
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("volgroup must be given a list of partitions")), lineno=self.lineno)
+            raise KickstartParseError(_("volgroup must be given a list of partitions"), lineno=self.lineno)
         elif ns.partitions and ns.preexist:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=_("Members may not be specified for preexisting volgroup")), lineno=self.lineno)
+            raise KickstartParseError(_("Members may not be specified for preexisting volgroup"), lineno=self.lineno)
         vg.vgname = ns.name[0]
 
         if ns.partitions:
@@ -208,20 +208,20 @@ class F16_VolGroup(FC3_VolGroup):
 
         # Check that any reserved space options are in their valid ranges.
         if getattr(retval, "reserved_space", None) and retval.reserved_space < 0:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg="Volume group reserved space must be a positive integer."), lineno=self.lineno)
+            raise KickstartParseError("Volume group reserved space must be a positive integer.", lineno=self.lineno)
 
         if getattr(retval, "reserved_percent", None) is not None and not 0 < retval.reserved_percent < 100:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg="Volume group reserved space percentage must be between 1 and 99."), lineno=self.lineno)
+            raise KickstartParseError("Volume group reserved space percentage must be between 1 and 99.", lineno=self.lineno)
 
         # the volgroup command can't be used together with the autopart command
         # due to the hard to debug behavior their combination introduces
         if self.handler.autopart.seen:
             errorMsg = _("The volgroup and autopart commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         # the same applies to the 'mount' command
         if hasattr(self.handler, "mount") and self.handler.mount.seen:
             errorMsg = _("The volgroup and mount commands can't be used at the same time")
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=errorMsg), lineno=self.lineno)
+            raise KickstartParseError(errorMsg, lineno=self.lineno)
         return retval
 
 class F21_VolGroup(F16_VolGroup):

--- a/pykickstart/errors.py
+++ b/pykickstart/errors.py
@@ -20,11 +20,7 @@
 """
 Error handling classes and functions.
 
-This module exports a single function:
-
-    formatErrorMsg - Properly formats an error message.
-
-It also exports several exception classes:
+This module exports several exception classes:
 
     KickstartError - A generic exception class.
 
@@ -36,24 +32,58 @@ It also exports several exception classes:
     KickstartVersionError - An exception for errors relating to unsupported
                             syntax versions.
 """
+import warnings
 from pykickstart.i18n import _
 
+
 def formatErrorMsg(lineno, msg=""):
-    """Properly format the error message msg for inclusion in an exception."""
+    """This function is deprecated. KickstartError formats the error message now,
+       so this function returns a tuple that can be formatted by KickstartError.
+
+       You should call:
+       KickstartError(message, lineno=lineno)
+
+       But the deprecated way is still supported:
+       KickstartError(formatErrorMsg(message, lineno=lineno))
+
+    """
+    warnings.warn("Function formatErrorMsg is deprecated. The error messages "
+                  "are formatted by KickstartError now.", DeprecationWarning)
+
+    return lineno, msg
+
+def _format_error_message(lineno, msg=""):
+    """Properly format the error message msg in an exception.
+       This function should be called only in exceptions to format the error messages.
+    """
     if msg:
-        mapping = {"lineno": lineno, "msg": msg}
-        return _("The following problem occurred on line %(lineno)s of the kickstart file:\n\n%(msg)s\n") % mapping
-    else:
-        return _("There was a problem reading from line %s of the kickstart file") % lineno
+        return _("The following problem occurred on line %(lineno)s of the kickstart file:"
+                 "\n\n%(msg)s\n") % {"lineno": lineno, "msg": msg}
+
+    return _("There was a problem reading from line %s of the kickstart file") % lineno
 
 class KickstartError(Exception):
     """A generic exception class for unspecific error conditions."""
-    def __init__(self, val=""):
+
+    def __init__(self, msg="", lineno=None, formatting=True):
         """Create a new KickstartError exception instance with the descriptive
-           message val.  val should be the return value of formatErrorMsg.
+           message msg. The msg will be formatted if formatting is allowed and
+           the line number lineno is set.
         """
         Exception.__init__(self)
-        self.value = val
+        self.message = msg
+        self.lineno = lineno
+
+        # Accept tuples from formatErrorMsg for backwards compatibility.
+        if isinstance(msg, tuple) and len(msg) == 2:
+            self.lineno, self.message = msg
+
+        # Keep the value attribute for backwards compatibility.
+        self.value = self.message
+
+        # Format the error message if it is allowed.
+        if formatting and self.lineno is not None:
+            self.value = _format_error_message(self.lineno, self.message)
 
     def __str__(self):
         return self.value
@@ -62,37 +92,16 @@ class KickstartParseError(KickstartError):
     """An exception class for errors when processing the input file, such as
        unknown options, commands, or sections.
     """
-    def __init__(self, msg, lineno=None):
-        """Create a new KickstartParseError exception instance with the
-           descriptive message msg.  msg should be the return value of
-           formatErrorMsg.
-        """
-        KickstartError.__init__(self, msg)
-        self.lineno = lineno
-
-    def __str__(self):
-        return self.value
+    pass
 
 class KickstartValueError(KickstartError):
     """This exception class is no longer raised by pykickstart but is kept
        for backwards compatibility.
     """
-    def __init__(self, msg):
-        KickstartError.__init__(self, msg)
-
-    def __str__(self):
-        return self.value
+    pass
 
 class KickstartVersionError(KickstartError):
     """An exception class for errors related to using an incorrect version of
        kickstart syntax.
     """
-    def __init__(self, msg):
-        """Create a new KickstartVersionError exception instance with the
-           descriptive message msg.  msg should be the return value of
-           formatErrorMsg.
-        """
-        KickstartError.__init__(self, msg)
-
-    def __str__(self):
-        return self.value
+    pass

--- a/pykickstart/options.py
+++ b/pykickstart/options.py
@@ -48,7 +48,7 @@ import textwrap
 from argparse import RawTextHelpFormatter, SUPPRESS
 from argparse import Action, ArgumentParser, ArgumentTypeError
 
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.version import versionToString, versionToLongString
 
 from pykickstart.i18n import _
@@ -254,7 +254,7 @@ class KSOptionParser(ArgumentParser):
     def error(self, message):
         # Overridden to turn errors into KickstartParseErrors.
         if self.lineno is not None:
-            raise KickstartParseError(formatErrorMsg(self.lineno, msg=message), lineno=self.lineno)
+            raise KickstartParseError(message, lineno=self.lineno)
         else:
             raise KickstartParseError(message)
 

--- a/pykickstart/parser.py
+++ b/pykickstart/parser.py
@@ -42,7 +42,7 @@ import warnings
 from ordered_set import OrderedSet
 
 from pykickstart import constants, version
-from pykickstart.errors import KickstartError, KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartError, KickstartParseError
 from pykickstart.ko import KickstartObject
 from pykickstart.load import load_to_str
 from pykickstart.options import KSOptionParser
@@ -87,12 +87,12 @@ def _preprocessStateMachine(lineIter):
         try:
             ksurl = ll.split(' ')[1]
         except:
-            raise KickstartParseError(formatErrorMsg(lineno, msg=_("Illegal url for %%ksappend: %s") % ll), lineno=lineno)
+            raise KickstartParseError(_("Illegal url for %%ksappend: %s") % ll, lineno=lineno)
 
         try:
             contents = load_to_str(ksurl)
         except KickstartError as e:
-            raise KickstartError(formatErrorMsg(lineno, msg=_("Unable to open %%ksappend file: %s") % str(e)))
+            raise KickstartError(_("Unable to open %%ksappend file: %s") % str(e), lineno=lineno)
 
         # If that worked, write the remote file to the output kickstart
         # file in one burst.  This allows multiple %ksappend lines to
@@ -120,7 +120,7 @@ def preprocessKickstartToString(f):
     try:
         contents = load_to_str(f)
     except KickstartError as e:
-        raise KickstartError(formatErrorMsg(0, msg=_("Unable to open input kickstart file: %s") % str(e)))
+        raise KickstartError(_("Unable to open input kickstart file: %s") % str(e), lineno=0)
 
     return _preprocessStateMachine(iter(contents.splitlines(True)))
 
@@ -613,7 +613,7 @@ class KickstartParser(object):
                 if line == "" and self._includeDepth == 0:
                     # This section ends at the end of the file.
                     if self.version >= version.F8:
-                        raise KickstartParseError(formatErrorMsg(lineno, msg=_("Section %s does not end with %%end.") % obj.sectionOpen), lineno=lineno)
+                        raise KickstartParseError(_("Section %s does not end with %%end.") % obj.sectionOpen, lineno=lineno)
 
                     self._finalize(obj)
             except StopIteration:
@@ -645,7 +645,7 @@ class KickstartParser(object):
                     break
                 elif args and args[0] == "%include":
                     if len(args) == 1 or not args[1]:
-                        raise KickstartParseError(formatErrorMsg(lineno), lineno=lineno)
+                        raise KickstartParseError(lineno=lineno)
 
                     self._handleInclude(args[1])
                     continue
@@ -654,7 +654,7 @@ class KickstartParser(object):
                 elif args and self._validState(args[0]):
                     # This is an unterminated section.
                     if self.version >= version.F8:
-                        raise KickstartParseError(formatErrorMsg(lineno, msg=_("Section %s does not end with %%end.") % obj.sectionOpen), lineno=lineno)
+                        raise KickstartParseError(_("Section %s does not end with %%end.") % obj.sectionOpen, lineno=lineno)
 
                     # Finish up.  We do not process the header here because
                     # kicking back out to STATE_COMMANDS will ensure that happens.
@@ -733,7 +733,7 @@ class KickstartParser(object):
 
             if args[0] == "%include":
                 if len(args) == 1 or not args[1]:
-                    raise KickstartParseError(formatErrorMsg(lineno), lineno=lineno)
+                    raise KickstartParseError(lineno=lineno)
 
                 self._handleInclude(args[1])
                 continue
@@ -749,7 +749,7 @@ class KickstartParser(object):
                     newSection = args[0]
                     if not self._validState(newSection):
                         if self.unknownSectionIsFatal:
-                            raise KickstartParseError(formatErrorMsg(lineno, msg=_("Unknown kickstart section: %s") % newSection), lineno=lineno)
+                            raise KickstartParseError(_("Unknown kickstart section: %s") % newSection, lineno=lineno)
                         else:
                             # If we are ignoring unknown section errors, just create a new
                             # NullSection for the header we just saw.  Then nothing else
@@ -810,7 +810,7 @@ class KickstartParser(object):
         try:
             s = load_to_str(f)
         except KickstartError as e:
-            raise KickstartError(formatErrorMsg(0, msg=_("Unable to open input kickstart file: %s") % str(e)))
+            raise KickstartError(_("Unable to open input kickstart file: %s") % str(e), lineno=0)
 
         self.readKickstartFromString(s, reset=False)
 

--- a/pykickstart/sections.py
+++ b/pykickstart/sections.py
@@ -32,7 +32,7 @@ parser.registerSection with an instance of your new class.
 from pykickstart.constants import KS_SCRIPT_PRE, KS_SCRIPT_POST, KS_SCRIPT_TRACEBACK, \
                                   KS_SCRIPT_PREINSTALL, KS_SCRIPT_ONERROR, \
                                   KS_MISSING_IGNORE, KS_MISSING_PROMPT
-from pykickstart.errors import KickstartParseError, formatErrorMsg
+from pykickstart.errors import KickstartParseError
 from pykickstart.options import KSOptionParser
 from pykickstart.version import FC4, F7, F9, F18, F21, F22, F24, RHEL7
 from pykickstart.i18n import _
@@ -624,9 +624,9 @@ class PackageSection(Section):
         ns = op.parse_args(args=args[1:], lineno=lineno)
 
         if ns.defaultPackages and ns.nobase:
-            raise KickstartParseError(formatErrorMsg(lineno, msg=_("--default and --nobase cannot be used together")), lineno=lineno)
+            raise KickstartParseError(_("--default and --nobase cannot be used together"), lineno=lineno)
         elif ns.defaultPackages and ns.nocore:
-            raise KickstartParseError(formatErrorMsg(lineno, msg=_("--default and --nocore cannot be used together")), lineno=lineno)
+            raise KickstartParseError(_("--default and --nocore cannot be used together"), lineno=lineno)
 
         self.handler.packages.excludeDocs = ns.excludedocs
         self.handler.packages.addBase = not ns.nobase

--- a/tests/errors.py
+++ b/tests/errors.py
@@ -1,21 +1,109 @@
 import unittest
 from tests.baseclass import ParserTest
 
-from pykickstart.errors import formatErrorMsg, KickstartError, KickstartParseError, KickstartVersionError
+from pykickstart.errors import formatErrorMsg, KickstartError, KickstartParseError, \
+    KickstartVersionError, _format_error_message
 
-class NoErrorMessage_TestCase(ParserTest):
+
+class ErrorMessage_TestCase(ParserTest):
     def runTest(self):
         # For now, just verify that calling formatErrorMsg with no message
         # returns something.  Digging in and checking what the message is
         # when we could be running "make check" in another language is hard.
-        self.assertNotEqual(formatErrorMsg(47), "")
 
-class ExceptionStr_TestCase(ParserTest):
+        # NOTE: formatErrorMsg is replaced with _format_error_message.
+        self.assertNotEqual(_format_error_message(47), "")
+
+        # Function formatErrorMsg is deprecated and returns its arguments now.
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(formatErrorMsg(47), (47, ""))
+
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(formatErrorMsg(47, "OH NO!"), (47, "OH NO!"))
+
+
+class Exception_TestCase(ParserTest):
     def runTest(self):
-        # Yes, I am aware I'm just checking off boxes now.
         self.assertEqual(str(KickstartError("OH NO!")), "OH NO!")
         self.assertEqual(str(KickstartParseError("OH NO!")), "OH NO!")
         self.assertEqual(str(KickstartVersionError("OH NO!")), "OH NO!")
+
+        err = KickstartError()
+        self.assertEqual(err.message, "")
+        self.assertEqual(err.lineno, None)
+        self.assertEqual(err.value, "")
+        self.assertEqual(str(err), "")
+
+        err = KickstartError("OH NO!")
+        self.assertEqual(err.message, "OH NO!")
+        self.assertEqual(err.lineno, None)
+        self.assertEqual(err.value, "OH NO!")
+        self.assertEqual(str(err), "OH NO!")
+
+        err = KickstartError(lineno=0)
+        self.assertEqual(err.message, "")
+        self.assertEqual(err.lineno, 0)
+        self.assertEqual(err.value, _format_error_message(msg="", lineno=0))
+        self.assertEqual(str(err), _format_error_message(msg="", lineno=0))
+
+        err = KickstartError(lineno=1)
+        self.assertEqual(err.message, "")
+        self.assertEqual(err.lineno, 1)
+        self.assertEqual(err.value, _format_error_message(msg="", lineno=1))
+        self.assertEqual(str(err), _format_error_message(msg="", lineno=1))
+
+        err = KickstartError("OH NO!", lineno=0)
+        self.assertEqual(err.message, "OH NO!")
+        self.assertEqual(err.lineno, 0)
+        self.assertEqual(err.value, _format_error_message(msg="OH NO!", lineno=0))
+        self.assertEqual(str(err), _format_error_message(msg="OH NO!", lineno=0))
+
+        err = KickstartError("OH NO!", lineno=1)
+        self.assertEqual(err.message, "OH NO!")
+        self.assertEqual(err.lineno, 1)
+        self.assertEqual(err.value, _format_error_message(msg="OH NO!", lineno=1))
+        self.assertEqual(str(err), _format_error_message(msg="OH NO!", lineno=1))
+
+        err = KickstartError("OH NO!", lineno=1, formatting=True)
+        self.assertEqual(err.message, "OH NO!")
+        self.assertEqual(err.lineno, 1)
+        self.assertEqual(err.value, _format_error_message(msg="OH NO!", lineno=1))
+        self.assertEqual(str(err), _format_error_message(msg="OH NO!", lineno=1))
+
+        err = KickstartError("OH NO!", lineno=1, formatting=False)
+        self.assertEqual(err.message, "OH NO!")
+        self.assertEqual(err.lineno, 1)
+        self.assertEqual(err.value, "OH NO!")
+        self.assertEqual(str(err), "OH NO!")
+
+        with self.assertWarns(DeprecationWarning):
+            err = KickstartError(formatErrorMsg(lineno=0))
+            self.assertEqual(err.message, "")
+            self.assertEqual(err.lineno, 0)
+            self.assertEqual(err.value, _format_error_message(msg="", lineno=0))
+            self.assertEqual(str(err), _format_error_message(msg="", lineno=0))
+
+        with self.assertWarns(DeprecationWarning):
+            err = KickstartError(formatErrorMsg(lineno=1))
+            self.assertEqual(err.message, "")
+            self.assertEqual(err.lineno, 1)
+            self.assertEqual(err.value, _format_error_message(msg="", lineno=1))
+            self.assertEqual(str(err), _format_error_message(msg="", lineno=1))
+
+        with self.assertWarns(DeprecationWarning):
+            err = KickstartError(formatErrorMsg(msg="OH NO!", lineno=0))
+            self.assertEqual(err.message, "OH NO!")
+            self.assertEqual(err.lineno, 0)
+            self.assertEqual(err.value, _format_error_message(msg="OH NO!", lineno=0))
+            self.assertEqual(str(err), _format_error_message(msg="OH NO!", lineno=0))
+
+        with self.assertWarns(DeprecationWarning):
+            err = KickstartError(formatErrorMsg(msg="OH NO!", lineno=1))
+            self.assertEqual(err.message, "OH NO!")
+            self.assertEqual(err.lineno, 1)
+            self.assertEqual(err.value, _format_error_message(msg="OH NO!", lineno=1))
+            self.assertEqual(str(err), _format_error_message(msg="OH NO!", lineno=1))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In anaconda, we need to be able to access the original error
message and the line number where the error occurred. It wasn't
possible when `KickstartError` received only the formatted message.

Now, `KickstartError` handles the error message formatting and it
keeps the original message and the line number. The function
`formatErrorMsg` is deprecated.

The recommended way of creating an exception:

    `KickstartError(message, lineno=lineno)`

The deprecated way is still supported:

    `KickstartError(formatErrorMsg(message, lineno=lineno))`