### PR TITLE
Fix deprecated commands with data

### DIFF
--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -196,6 +196,15 @@ class DeprecatedCommand(KickstartCommand):
         # Create a new DeprecatedCommand instance.
         KickstartCommand.__init__(self, writePriority, *args, **kwargs)
 
+    def dataList(self):
+        """Override the method of the deprecated command."""
+        return None
+
+    @property
+    def dataClass(self):
+        """Override the attribute of the deprecated command."""
+        return None
+
     def __str__(self):
         """Placeholder since DeprecatedCommands don't work anymore."""
         return ""

--- a/tests/misc.py
+++ b/tests/misc.py
@@ -1,4 +1,8 @@
 import unittest
+import warnings
+
+from pykickstart.parser import KickstartParser
+from pykickstart.version import makeVersion
 from tests.baseclass import ParserTest
 from pykickstart.handlers import control
 from pykickstart.base import DeprecatedCommand
@@ -52,6 +56,23 @@ class WritePriority_TestCase(unittest.TestCase):
                     self.assertEqual(140, cmd.writePriority, command_class)
                 else:
                     self.assertEqual(0, cmd.writePriority, command_class)
+
+class DeprecatedCommandsParsing_TestCase(unittest.TestCase):
+    def runTest(self):
+        for version, command_map in control.commandMap.items():
+
+            handler = makeVersion(version)
+            parser = KickstartParser(handler)
+
+            for command_name, command_class in command_map.items():
+                if not issubclass(command_class, DeprecatedCommand):
+                    continue
+
+                with warnings.catch_warnings(record=True):
+                    # The deprecated commands should be ignored with
+                    # a warning when they are parsed. Make sure that
+                    # they will not cause any errors.
+                    parser.readKickstartFromString(command_name)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
It wasn't possible to parse deprecated commands with data,
for example device, dmraid and multipath in Fedora 28.

Added a test that will try to parse all deprecated commands.