### PR TITLE
Include the _sortCommand to the _setCommand method (#1578930)

### DIFF
--- a/pykickstart/base.py
+++ b/pykickstart/base.py
@@ -306,7 +306,6 @@ class KickstartHandler(KickstartObject):
 
         setattr(self, name.lower(), cmdObj)
 
-    def _sortCommand(self, cmdObj):
         # Also, add the object into the _writeOrder dict in the right place.
         if cmdObj.writePriority is not None:
             if cmdObj.writePriority in self._writeOrder:
@@ -332,7 +331,6 @@ class KickstartHandler(KickstartObject):
         if cmdObj is None:
             cmdObj = cmdClass()
             self._setCommand(cmdObj)
-            self._sortCommand(cmdObj)
 
         # Finally, add the mapping to the commands dict.
         self.commands[cmdName] = cmdObj

--- a/tests/base.py
+++ b/tests/base.py
@@ -232,6 +232,7 @@ class HandlerResetCommand_TestCase(ParserTest):
         self.assertTrue(self.handler.autopart.encrypted)
         self.assertEqual(self.handler.autopart.passphrase, "something")
         self.assertTrue(self.handler.autopart.bogus)
+        self.assertTrue("autopart" in str(self.handler))
 
         self.handler.resetCommand("autopart")
         self.assertFalse(self.handler.autopart.autopart)
@@ -239,6 +240,7 @@ class HandlerResetCommand_TestCase(ParserTest):
         self.assertFalse(self.handler.autopart.encrypted)
         self.assertEqual(self.handler.autopart.passphrase, "")
         self.assertNotIn("bogus", self.handler.autopart.__dict__)
+        self.assertFalse("autopart" in str(self.handler))
 
 class HandlerDispatch_TestCase(ParserTest):
     def runTest(self):


### PR DESCRIPTION
The _sortCommand method should be part of the _setCommand method,
otherwise we might set the command without changing the _writeOrder
dictionary.

This should fix the resetCommand method, where the dictionary wasn't
updated, so the old instance of the command was used to generate the
kickstart representation.

Resolves: rhbz#1578930