### PR TITLE
Deprecate commands and options in another handler

### DIFF
--- a/pykickstart/commands/bootloader.py
+++ b/pykickstart/commands/bootloader.py
@@ -485,9 +485,6 @@ class F21_Bootloader(F19_Bootloader):
 class RHEL7_Bootloader(F21_Bootloader):
     pass
 
-class RHEL8_Bootloader(F21_Bootloader):
-    pass
-
 class F29_Bootloader(F21_Bootloader):
     removedKeywords = F21_Bootloader.removedKeywords
     removedAttrs = F21_Bootloader.removedAttrs
@@ -497,3 +494,6 @@ class F29_Bootloader(F21_Bootloader):
         op.add_argument("--upgrade", action="store_true", default=False,
                         deprecated=F29, help="")
         return op
+
+class RHEL8_Bootloader(F29_Bootloader):
+    pass

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -661,28 +661,6 @@ class F23_Partition(F20_Partition):
 class RHEL7_Partition(F23_Partition):
     pass
 
-class RHEL8_Partition(F23_Partition):
-    removedKeywords = F23_Partition.removedKeywords
-    removedAttrs = F23_Partition.removedAttrs
-
-    def parse(self, args):
-        retval = F23_Partition.parse(self, args)
-        if retval.mountpoint.startswith("btrfs.") or retval.fstype == "btrfs":
-            raise KickstartParseError(_("Btrfs file system is not supported"), lineno=self.lineno)
-        return retval
-
-    def _getParser(self):
-        "Only necessary for the type change documentation"
-        op = F23_Partition._getParser(self)
-        for action in op._actions:
-            if "--fstype" in action.option_strings:
-                action.help += """
-
-                    .. versionchanged:: %s
-
-                    Btrfs support was removed.""" % versionToLongString(RHEL8)
-        return op
-
 class F29_Partition(F23_Partition):
     removedKeywords = F23_Partition.removedKeywords
     removedAttrs = F23_Partition.removedAttrs
@@ -691,4 +669,26 @@ class F29_Partition(F23_Partition):
         op = F23_Partition._getParser(self)
         op.add_argument("--active", action="store_true", default=False,
                         deprecated=F29, help="")
+        return op
+
+class RHEL8_Partition(F29_Partition):
+    removedKeywords = F29_Partition.removedKeywords
+    removedAttrs = F29_Partition.removedAttrs
+
+    def parse(self, args):
+        retval = F29_Partition.parse(self, args)
+        if retval.mountpoint.startswith("btrfs.") or retval.fstype == "btrfs":
+            raise KickstartParseError(_("Btrfs file system is not supported"), lineno=self.lineno)
+        return retval
+
+    def _getParser(self):
+        "Only necessary for the type change documentation"
+        op = F29_Partition._getParser(self)
+        for action in op._actions:
+            if "--fstype" in action.option_strings:
+                action.help += """
+
+                    .. versionchanged:: %s
+
+                    Btrfs support was removed.""" % versionToLongString(RHEL8)
         return op

--- a/pykickstart/handlers/rhel8.py
+++ b/pykickstart/handlers/rhel8.py
@@ -49,7 +49,7 @@ class RHEL8Handler(BaseHandler):
         "halt": commands.reboot.F23_Reboot,
         "harddrive": commands.harddrive.FC3_HardDrive,
         "hmc" : commands.hmc.F28_Hmc,
-        "ignoredisk": commands.ignoredisk.F14_IgnoreDisk,
+        "ignoredisk": commands.ignoredisk.F29_IgnoreDisk,
         "install": commands.install.F29_Install,
         "iscsi": commands.iscsi.F17_Iscsi,
         "iscsiname": commands.iscsiname.FC6_IscsiName,

--- a/pykickstart/handlers/rhel8.py
+++ b/pykickstart/handlers/rhel8.py
@@ -50,7 +50,7 @@ class RHEL8Handler(BaseHandler):
         "harddrive": commands.harddrive.FC3_HardDrive,
         "hmc" : commands.hmc.F28_Hmc,
         "ignoredisk": commands.ignoredisk.F14_IgnoreDisk,
-        "install": commands.install.F20_Install,
+        "install": commands.install.F29_Install,
         "iscsi": commands.iscsi.F17_Iscsi,
         "iscsiname": commands.iscsiname.FC6_IscsiName,
         "keyboard": commands.keyboard.F18_Keyboard,

--- a/pykickstart/handlers/rhel8.py
+++ b/pykickstart/handlers/rhel8.py
@@ -86,7 +86,6 @@ class RHEL8Handler(BaseHandler):
         "text": commands.displaymode.F26_DisplayMode,
         "timezone": commands.timezone.F25_Timezone,
         "updates": commands.updates.F7_Updates,
-        "upgrade": commands.upgrade.F20_Upgrade,
         "url": commands.url.F27_Url,
         "user": commands.user.F24_User,
         "vnc": commands.vnc.F9_Vnc,

--- a/pykickstart/handlers/rhel8.py
+++ b/pykickstart/handlers/rhel8.py
@@ -37,7 +37,7 @@ class RHEL8Handler(BaseHandler):
         "clearpart": commands.clearpart.F28_ClearPart,
         "cmdline": commands.displaymode.F26_DisplayMode,
         "device": commands.device.F24_Device,
-        "deviceprobe": commands.deviceprobe.FC3_DeviceProbe,
+        "deviceprobe": commands.deviceprobe.F29_DeviceProbe,
         "dmraid": commands.dmraid.F24_DmRaid,
         "driverdisk": commands.driverdisk.F14_DriverDisk,
         "eula": commands.eula.F20_Eula,

--- a/tests/commands/bootloader.py
+++ b/tests/commands/bootloader.py
@@ -186,5 +186,8 @@ class F29_TestCase(F21_TestCase):
         F21_TestCase.runTest(self, iscrypted=iscrypted)
         self.assert_deprecated("bootloader", "--upgrade")
 
+class RHEL8_TestCase(F29_TestCase):
+    pass
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/deviceprobe.py
+++ b/tests/commands/deviceprobe.py
@@ -40,5 +40,8 @@ class F29_TestCase(FC3_TestCase):
         # make sure we are still able to parse
         self.assert_parse("deviceprobe")
 
+class RHEL8_TestCase(F29_TestCase):
+    pass
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/ignoredisk.py
+++ b/tests/commands/ignoredisk.py
@@ -89,5 +89,8 @@ class F29_TestCase(F8_TestCase):
         F8_TestCase.runTest(self)
         self.assert_deprecated("ignoredisk", "--interactive")
 
+class RHEL8_TestCase(F29_TestCase):
+    pass
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/install.py
+++ b/tests/commands/install.py
@@ -52,5 +52,8 @@ class F29_TestCase(F20_TestCase):
         # make sure we are still able to parse it
         self.assert_parse("install")
 
+class RHEL8_TestCase(F29_TestCase):
+    pass
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/partition.py
+++ b/tests/commands/partition.py
@@ -311,5 +311,8 @@ class F29_TestCase(F23_TestCase):
         self.assert_deprecated("part", "--active")
         self.assert_deprecated("partition", "--active")
 
+class RHEL8_TestCase(F29_TestCase):
+    pass
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/commands/upgrade.py
+++ b/tests/commands/upgrade.py
@@ -82,5 +82,8 @@ class F29_TestCase(F20_TestCase):
         # make sure that upgrade is removed
         self.assertNotIn("upgrade", self.handler().commands)
 
+class RHEL8_TestCase(F29_TestCase):
+    pass
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Apply the changes in https://github.com/clumens/pykickstart/pull/217 to another handler.