### PR TITLE
Normalize the mount point

### DIFF
--- a/pykickstart/commands/btrfs.py
+++ b/pykickstart/commands/btrfs.py
@@ -21,7 +21,7 @@
 from pykickstart.version import F17, F23, RHEL8, versionToLongString
 from pykickstart.base import BaseData, KickstartCommand, DeprecatedCommand
 from pykickstart.errors import KickstartParseError, KickstartParseWarning
-from pykickstart.options import KSOptionParser
+from pykickstart.options import KSOptionParser, mountpoint
 
 import warnings
 from pykickstart.i18n import _
@@ -217,7 +217,7 @@ class F17_BTRFS(KickstartCommand):
             mapping = {"command": "btrfs", "options": extra}
             raise KickstartParseError(_("Unexpected arguments to %(command)s command: %(options)s") % mapping, lineno=self.lineno)
 
-        data.mountpoint = extra[0]
+        data.mountpoint = mountpoint(extra[0])
         data.devices = extra[1:]
 
         if not any([data.devices, data.subvol]):

--- a/pykickstart/commands/logvol.py
+++ b/pykickstart/commands/logvol.py
@@ -21,7 +21,7 @@ from pykickstart.version import FC3, FC4, F9, F12, F14, F15, F17, F18, F20, F21,
 from pykickstart.version import F23, RHEL5, RHEL6, RHEL7, RHEL8, versionToLongString
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartParseWarning
-from pykickstart.options import KSOptionParser, commaSplit
+from pykickstart.options import KSOptionParser, commaSplit, mountpoint
 
 import warnings
 from pykickstart.i18n import _
@@ -415,8 +415,10 @@ class FC3_LogVol(KickstartCommand):
                                 volgroup myvg pv.01
                                 logvol / --vgname=myvg --size=2000 --name=rootvol
                             """)
-        op.add_argument("mntpoint", metavar="<mntpoint>", nargs=1, version=FC3,
-                        help="Mountpoint for this logical volume or 'none'.")
+        op.add_argument("mntpoint", metavar="<mntpoint>", type=mountpoint, nargs=1,
+                        version=FC3, help="""
+                        Mountpoint for this logical volume or 'none'.
+                        """)
         op.add_argument("--fstype", version=FC3, help="""
                         Sets the file system type for the logical volume. Valid
                         values include ext4, ext3, ext2, btrfs, swap, and vfat.

--- a/pykickstart/commands/mount.py
+++ b/pykickstart/commands/mount.py
@@ -20,7 +20,7 @@
 
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartParseError
-from pykickstart.options import KSOptionParser
+from pykickstart.options import KSOptionParser, mountpoint
 from pykickstart.version import F27
 
 from pykickstart.i18n import _
@@ -115,8 +115,8 @@ class F27_Mount(KickstartCommand):
 
         op.add_argument("device", metavar="<device>", nargs=1, version=F27,
                         help="""The block device to mount""")
-        op.add_argument("mntpoint", metavar="<mntpoint>", nargs=1, version=F27,
-                        help="""
+        op.add_argument("mntpoint", metavar="<mntpoint>", type=mountpoint, nargs=1,
+                        version=F27, help="""
                         The ``<mntpoint>`` is where the <device> will be
                         mounted.  Must be a valid mount point, for example
                         ``/``, ``/usr``, ``/home``, or ``none`` if the device

--- a/pykickstart/commands/partition.py
+++ b/pykickstart/commands/partition.py
@@ -21,7 +21,7 @@ from pykickstart.version import RHEL5, RHEL6, RHEL8, versionToLongString
 from pykickstart.version import FC3, FC4, F9, F11, F12, F14, F17, F18, F23, F29
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartParseWarning
-from pykickstart.options import KSOptionParser
+from pykickstart.options import KSOptionParser, mountpoint
 
 import warnings
 from pykickstart.i18n import _
@@ -334,8 +334,8 @@ class FC3_Partition(KickstartCommand):
                             If partitioning fails for any reason, diagnostic
                             messages will appear on virtual console 3.""",
                             version=FC3)
-        op.add_argument("mntpoint", metavar="<mntpoint>", nargs=1, version=FC3,
-                        help="""
+        op.add_argument("mntpoint", metavar="<mntpoint>", type=mountpoint, nargs=1,
+                        version=FC3, help="""
                         The ``<mntpoint>`` is where the partition will be mounted
                         and must be of one of the following forms:
 

--- a/pykickstart/commands/raid.py
+++ b/pykickstart/commands/raid.py
@@ -22,7 +22,7 @@ from pykickstart.version import versionToLongString, RHEL5, RHEL6, FC3, FC4, FC5
 from pykickstart.version import F7, F9, F12, F13, F14, F15, F18, F23, F25, RHEL8
 from pykickstart.base import BaseData, KickstartCommand
 from pykickstart.errors import KickstartParseError, KickstartParseWarning
-from pykickstart.options import KSOptionParser
+from pykickstart.options import KSOptionParser, mountpoint
 
 import warnings
 from pykickstart.i18n import _
@@ -371,8 +371,8 @@ class FC3_Raid(KickstartCommand):
                                 raid / --level=1 --device=md0 raid.01 raid.02 raid.03
                                 raid /usr --level=5 --device=md1 raid.11 raid.12 raid.13
                             """, version=FC3)
-        op.add_argument("mntpoint", metavar="<mntpoint>", nargs=1, version=FC3,
-                        help="""
+        op.add_argument("mntpoint", metavar="<mntpoint>", type=mountpoint, nargs=1,
+                        version=FC3, help="""
                         Location where the RAID file system is mounted. If it
                         is /, the RAID level must be 1 unless a boot partition
                         (/boot) is present. If a boot partition is present, the

--- a/pykickstart/options.py
+++ b/pykickstart/options.py
@@ -43,6 +43,7 @@ And it exports two functions:
     ksboolean - A function to be used as the type= argument to any arguments
                 that can take a boolean.
 """
+import os
 import warnings
 import textwrap
 from argparse import RawTextHelpFormatter, SUPPRESS
@@ -66,6 +67,12 @@ def ksboolean(value):
             raise ArgumentTypeError(_("invalid boolean value: %r") % value)
     except AttributeError:
         raise ArgumentTypeError(_("invalid boolean value: %r") % value)
+
+def mountpoint(value):
+    if value.startswith("/"):
+        return os.path.normpath(value)
+
+    return value
 
 class KSHelpFormatter(RawTextHelpFormatter):
     """

--- a/tests/options.py
+++ b/tests/options.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentTypeError
 from tests.baseclass import ParserTest
 
-from pykickstart.options import ksboolean
+from pykickstart.options import ksboolean, mountpoint
 
 class Ksboolean_TestCase(ParserTest):
     def runTest(self):
@@ -28,3 +28,14 @@ class Ksboolean_TestCase(ParserTest):
         self.assertRaises(ArgumentTypeError, ksboolean, None)
         self.assertRaises(ArgumentTypeError, ksboolean, [])
         self.assertRaises(ArgumentTypeError, ksboolean, {})
+
+
+class Mountpoint_TestCase(ParserTest):
+    def runTest(self):
+        self.assertEqual(mountpoint("none"), "none")
+        self.assertEqual(mountpoint("swap"), "swap")
+        self.assertEqual(mountpoint("/"), "/")
+        self.assertEqual(mountpoint("/home"), "/home")
+        self.assertEqual(mountpoint("/home/"), "/home")
+        self.assertEqual(mountpoint("/var"), "/var")
+        self.assertEqual(mountpoint("/var/"), "/var")


### PR DESCRIPTION
If a mount point is specified as a path, we should normalize this path.
For example '/var/' should be normalized to '/var'.

Resolves: rhbz#1626557